### PR TITLE
Added showAll option for the Search page as a tri-state checkbox

### DIFF
--- a/apps/frontend/src/app/user.ts
+++ b/apps/frontend/src/app/user.ts
@@ -9,6 +9,7 @@ export interface UserState {
   showCourseInfos: boolean;
   showSchedules: boolean;
   loggedIn: boolean;
+  showAll: boolean;
   fceAggregation: {
     numSemesters: number;
     counted: {
@@ -31,6 +32,7 @@ const initialState: UserState = {
   showCourseInfos: true,
   showSchedules: false,
   loggedIn: false,
+  showAll: false,
   fceAggregation: {
     numSemesters: 2,
     counted: {
@@ -68,6 +70,9 @@ export const userSlice = createSlice({
     },
     showSchedules: (state, action: PayloadAction<boolean>) => {
       state.showSchedules = action.payload;
+    },
+    showAll : (state, action: PayloadAction<boolean>) => {
+      state.showAll = action.payload;
     },
     logIn: (state) => {
       state.loggedIn = true;

--- a/apps/frontend/src/components/SearchBar.tsx
+++ b/apps/frontend/src/components/SearchBar.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { throttledFilter } from "~/app/store";
 import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/solid";
@@ -154,6 +154,34 @@ const SearchBar = () => {
   const showCourseInfos = useAppSelector((state) => state.user.showCourseInfos);
   const showSchedules = useAppSelector((state) => state.user.showSchedules);
 
+  const showAll = useAppSelector((state) => state.user.showAll);
+
+  const showAllRef = useRef<any>(null);
+  useEffect(() => {
+    if (showAllRef.current) {
+      if (loggedIn) {
+        if ((showFCEs && showCourseInfos && showSchedules)) {
+          showAllRef.current.indeterminate = false;
+          showAllRef.current.checked = true;
+        } else if (!(showFCEs || showCourseInfos || showSchedules)) {
+          showAllRef.current.indeterminate = false;
+          showAllRef.current.checked = false;
+        } else
+          showAllRef.current.indeterminate = true;
+      } else {
+        console.log(showFCEs, showCourseInfos, showSchedules);
+        if ((showCourseInfos && showSchedules)) {
+          showAllRef.current.indeterminate = false;
+          showAllRef.current.checked = true;
+        } else if (!(showCourseInfos || showSchedules)) {
+          showAllRef.current.indeterminate = false;
+          showAllRef.current.checked = false;
+        } else
+          showAllRef.current.indeterminate = true;
+      }
+    }
+  }, [showAllRef, showAllRef.current, showFCEs, showCourseInfos, showSchedules]);
+
   const setShowFCEs = (e: React.ChangeEvent<HTMLInputElement>) => {
     dispatch(userSlice.actions.showFCEs(e.target.checked));
   };
@@ -163,6 +191,13 @@ const SearchBar = () => {
   };
 
   const setShowSchedules = (e: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(userSlice.actions.showSchedules(e.target.checked));
+  };
+
+  const setShowAll = (e: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(userSlice.actions.showAll(e.target.checked));
+    if (loggedIn) {dispatch(userSlice.actions.showFCEs(e.target.checked));}
+    dispatch(userSlice.actions.showCourseInfos(e.target.checked));
     dispatch(userSlice.actions.showSchedules(e.target.checked));
   };
 
@@ -187,6 +222,17 @@ const SearchBar = () => {
         <div className="mt-3 text-sm text-gray-400">{numResults} results</div>
         <div className="mt-3 flex justify-end text-gray-500">
           <div className="mr-6 hidden md:block">Show</div>
+          <div className="mr-6">
+            <input
+              id="selectAll"
+              type="checkbox"
+              className="mr-2"
+              onChange={setShowAll}
+              checked={showAll}
+              ref = {showAllRef}
+            />
+            <span>All</span>
+          </div>
           <div className="mr-6">
             <input
               type="checkbox"

--- a/apps/frontend/src/components/SearchBar.tsx
+++ b/apps/frontend/src/components/SearchBar.tsx
@@ -160,7 +160,7 @@ const SearchBar = () => {
   useEffect(() => {
     if (showAllRef.current) {
       if (loggedIn) {
-        if ((showFCEs && showCourseInfos && showSchedules)) {
+        if (showFCEs && showCourseInfos && showSchedules) {
           showAllRef.current.indeterminate = false;
           showAllRef.current.checked = true;
         } else if (!(showFCEs || showCourseInfos || showSchedules)) {
@@ -169,8 +169,7 @@ const SearchBar = () => {
         } else
           showAllRef.current.indeterminate = true;
       } else {
-        console.log(showFCEs, showCourseInfos, showSchedules);
-        if ((showCourseInfos && showSchedules)) {
+        if (showCourseInfos && showSchedules) {
           showAllRef.current.indeterminate = false;
           showAllRef.current.checked = true;
         } else if (!(showCourseInfos || showSchedules)) {
@@ -196,7 +195,7 @@ const SearchBar = () => {
 
   const setShowAll = (e: React.ChangeEvent<HTMLInputElement>) => {
     dispatch(userSlice.actions.showAll(e.target.checked));
-    if (loggedIn) {dispatch(userSlice.actions.showFCEs(e.target.checked));}
+    if (loggedIn) dispatch(userSlice.actions.showFCEs(e.target.checked));
     dispatch(userSlice.actions.showCourseInfos(e.target.checked));
     dispatch(userSlice.actions.showSchedules(e.target.checked));
   };


### PR DESCRIPTION
# Description

Added showAll option for the Search page as a tri-state checkbox, based on the show settings of FCEs, Course Info, and Schedules.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Trying out different combinations of show selections for FCEs, Course Info, and Schedules, for both logged-in users and guests.

**Test Configuration**:

- Node.js version: v20.16.0
- Desktop/Mobile: Desktop
- OS: Windows
- Browser: Chrome

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
