### PR TITLE
Add pre-/post-requisite tree under each class 

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -2,7 +2,7 @@ import morgan from "morgan";
 import express, { ErrorRequestHandler } from "express";
 import cors from "cors";
 import { isUser } from "~/controllers/user";
-import { getAllCourses, getCourseByID, getCourses, getFilteredCourses, getCourseRelations } from "~/controllers/courses";
+import { getAllCourses, getCourseByID, getCourses, getFilteredCourses, getRequisites } from "~/controllers/courses";
 import { getFCEs } from "~/controllers/fces";
 import { getInstructors } from "~/controllers/instructors";
 import { getGeneds } from "~/controllers/geneds";
@@ -21,7 +21,7 @@ app.route("/course/:courseID").get(getCourseByID);
 app.route("/courses").get(getCourses);
 app.route("/courses").post(isUser, getCourses);
 app.route("/courses/all").get(getAllCourses);
-app.route("/courses/relations").get(getCourseRelations);
+app.route("/courses/requisites/:courseID").get(getRequisites);
 app.route("/courses/search/").get(getFilteredCourses);
 app.route("/courses/search/").post(isUser, getFilteredCourses);
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -2,7 +2,7 @@ import morgan from "morgan";
 import express, { ErrorRequestHandler } from "express";
 import cors from "cors";
 import { isUser } from "~/controllers/user";
-import { getAllCourses, getCourseByID, getCourses, getFilteredCourses } from "~/controllers/courses";
+import { getAllCourses, getCourseByID, getCourses, getFilteredCourses, getCourseRelations } from "~/controllers/courses";
 import { getFCEs } from "~/controllers/fces";
 import { getInstructors } from "~/controllers/instructors";
 import { getGeneds } from "~/controllers/geneds";
@@ -21,6 +21,7 @@ app.route("/course/:courseID").get(getCourseByID);
 app.route("/courses").get(getCourses);
 app.route("/courses").post(isUser, getCourses);
 app.route("/courses/all").get(getAllCourses);
+app.route("/courses/relations").get(getCourseRelations);
 app.route("/courses/search/").get(getFilteredCourses);
 app.route("/courses/search/").post(isUser, getFilteredCourses);
 

--- a/apps/backend/src/controllers/courses.ts
+++ b/apps/backend/src/controllers/courses.ts
@@ -75,7 +75,6 @@ export const getCourses: RequestHandler<
         schedules: fromBoolLiteral(req.query.schedules),
       },
     });
-
     res.json(courses);
   } catch (e) {
     next(e);

--- a/apps/backend/src/controllers/courses.ts
+++ b/apps/backend/src/controllers/courses.ts
@@ -288,6 +288,7 @@ export const getRequisites: RequestHandler = async (req, res, next) => {
       where: { courseID },
       select: {
         courseID: true,
+        prereqs: true,
         prereqString: true,
       },
     });
@@ -312,6 +313,7 @@ export const getRequisites: RequestHandler = async (req, res, next) => {
     const postreqIDs = postreqs.map(postreq => postreq.courseID);
 
     const courseRequisites = {
+      prereqs: course.prereqs,
       prereqRelations: parsedPrereqs,
       postreqs: postreqIDs
     }

--- a/apps/backend/src/util.ts
+++ b/apps/backend/src/util.ts
@@ -41,3 +41,9 @@ export type PrismaReturn<PrismaFnType extends (...args: any) => any> =
 
 export type ElemType<ArrayType extends readonly unknown[]> =
   ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
+
+export function parsePrereqString(prereqString: string): string[][] {
+  const normalized = prereqString.replace(/\s+/g, "").replace(/[()]/g, ""); // Remove whitespace and parentheses
+  const andGroups = normalized.split("and"); // Split by AND groups
+  return andGroups.map((group) => group.split("or")); // Split each AND group into OR relationships
+}

--- a/apps/frontend/src/app/api/course.ts
+++ b/apps/frontend/src/app/api/course.ts
@@ -140,6 +140,7 @@ export const useFetchAllCourses = () => {
 };
 
 export type CourseRequisites = {
+  prereqs: string[];
   prereqRelations: string[][];
   postreqs: string[];
 };

--- a/apps/frontend/src/app/api/course.ts
+++ b/apps/frontend/src/app/api/course.ts
@@ -138,3 +138,28 @@ export const useFetchAllCourses = () => {
     staleTime: STALE_TIME,
   });
 };
+
+export type CourseRequisites = {
+  prereqRelations: string[][];
+  postreqs: string[];
+};
+
+export const fetchCourseRequisites = async (courseID: string): Promise<CourseRequisites> => {
+  const url = `${process.env.NEXT_PUBLIC_BACKEND_URL || ""}/courses/requisites/${courseID}`;
+
+  const response = await axios.get(url, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  return response.data;
+};
+
+export const useFetchCourseRequisites = (courseID: string) => {
+  return useQuery<CourseRequisites>({
+    queryKey: ['courseRequisites', courseID],
+    queryFn: () => fetchCourseRequisites(courseID),
+    staleTime: STALE_TIME,
+  });
+};

--- a/apps/frontend/src/app/types.ts
+++ b/apps/frontend/src/app/types.ts
@@ -20,7 +20,6 @@ export interface Session {
 export interface Course {
   prereqs: string[];
   prereqString: string;
-  postreqs: string[];
   coreqs: string[];
   crosslisted: string[];
   name: string;

--- a/apps/frontend/src/app/types.ts
+++ b/apps/frontend/src/app/types.ts
@@ -92,7 +92,6 @@ export interface Gened {
 
 export interface TreeNode {
   courseID: string;
-  coreqs?: Array<{ courseID: string }>;
   prereqs?: TreeNode[];
   prereqRelations?: TreeNode[][];
   postreqs?: TreeNode[];

--- a/apps/frontend/src/app/types.ts
+++ b/apps/frontend/src/app/types.ts
@@ -20,6 +20,7 @@ export interface Session {
 export interface Course {
   prereqs: string[];
   prereqString: string;
+  postreqs: string[];
   coreqs: string[];
   crosslisted: string[];
   name: string;

--- a/apps/frontend/src/app/types.ts
+++ b/apps/frontend/src/app/types.ts
@@ -90,3 +90,10 @@ export interface Gened {
   fces: FCE[];
 }
 
+export interface TreeNode {
+  courseID: string;
+  coreqs?: Array<{ courseID: string }>;
+  prereqs?: TreeNode[];
+  prereqRelations?: TreeNode[][];
+  postreqs?: TreeNode[];
+}

--- a/apps/frontend/src/components/Buttons.tsx
+++ b/apps/frontend/src/components/Buttons.tsx
@@ -33,3 +33,18 @@ export const FlushedButton = ({
     </div>
   );
 };
+
+export const CourseIDButton = ({
+  courseID,
+}: {
+  courseID: string;
+}) => {
+  return (
+    <button
+      onClick={() => (window.location.href = `/course/${courseID}`)}
+      className="font-normal text-center px-2 py-1 text-base bg-gray-50 hover:bg-gray-200 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-20 inline mt-1 mb-1"
+    >
+      {courseID}
+    </button>
+  )
+}

--- a/apps/frontend/src/components/CourseDetail.tsx
+++ b/apps/frontend/src/components/CourseDetail.tsx
@@ -29,4 +29,6 @@ const CourseDetail = ({ courseID }: Props) => {
   );
 };
 
+// Add the inputs/logic above inside {<ReqTreeCard> } (if no post/pre-requisites, display "No pre/poste-requisites" or similar)
+
 export default CourseDetail;

--- a/apps/frontend/src/components/CourseDetail.tsx
+++ b/apps/frontend/src/components/CourseDetail.tsx
@@ -24,18 +24,17 @@ const CourseDetail = ({ courseID }: Props) => {
       <CourseCard courseID={courseID} showFCEs={false} showCourseInfo={true} />
       
       {fces && <FCECard fces={fces} />}
-
       {info.schedules && (
         <SchedulesCard
           scheduleInfos={filterSessions([...info.schedules]).sort(compareSessions)}
         />
       )}
-
       {info.prereqs && info.postreqs && (
         <ReqTreeCard
           courseID={courseID}
           prereqs={info.prereqs}
           postreqs={info.postreqs}
+          coreqs={info.coreqs} // Ensure coreqs are passed here
         />
       )}
     </div>

--- a/apps/frontend/src/components/CourseDetail.tsx
+++ b/apps/frontend/src/components/CourseDetail.tsx
@@ -33,7 +33,7 @@ const CourseDetail = ({ courseID }: Props) => {
       {info.prereqs && requisites.prereqRelations && requisites.postreqs && (
         <ReqTreeCard
           courseID={courseID}
-          prereqs={info.prereqs}
+          prereqs={requisites.prereqs}
           prereqRelations={requisites.prereqRelations}
           postreqs={requisites.postreqs}
           coreqs={info.coreqs}

--- a/apps/frontend/src/components/CourseDetail.tsx
+++ b/apps/frontend/src/components/CourseDetail.tsx
@@ -24,7 +24,7 @@ const CourseDetail = ({ courseID }: Props) => {
           scheduleInfos={filterSessions([...schedules]).sort(compareSessions)}
         />
       )}
-      {< ReqTreeCard />}
+      {< ReqTreeCard courseID={courseID} />}
     </div>
   );
 };

--- a/apps/frontend/src/components/CourseDetail.tsx
+++ b/apps/frontend/src/components/CourseDetail.tsx
@@ -5,6 +5,7 @@ import { useFetchFCEInfoByCourse } from "~/app/api/fce";
 import { SchedulesCard } from "./SchedulesCard";
 import { FCECard } from "./FCECard";
 import { useFetchCourseInfo } from "~/app/api/course";
+import { ReqTreeCard } from "./ReqTreeCard";
 
 type Props = {
   courseID: string;

--- a/apps/frontend/src/components/CourseDetail.tsx
+++ b/apps/frontend/src/components/CourseDetail.tsx
@@ -24,6 +24,7 @@ const CourseDetail = ({ courseID }: Props) => {
           scheduleInfos={filterSessions([...schedules]).sort(compareSessions)}
         />
       )}
+      {< ReqTreeCard />}
     </div>
   );
 };

--- a/apps/frontend/src/components/CourseDetail.tsx
+++ b/apps/frontend/src/components/CourseDetail.tsx
@@ -36,7 +36,6 @@ const CourseDetail = ({ courseID }: Props) => {
           prereqs={requisites.prereqs}
           prereqRelations={requisites.prereqRelations}
           postreqs={requisites.postreqs}
-          coreqs={info.coreqs}
         />
       )}
     </div>

--- a/apps/frontend/src/components/CourseDetail.tsx
+++ b/apps/frontend/src/components/CourseDetail.tsx
@@ -4,7 +4,7 @@ import CourseCard from "./CourseCard";
 import { useFetchFCEInfoByCourse } from "~/app/api/fce";
 import { SchedulesCard } from "./SchedulesCard";
 import { FCECard } from "./FCECard";
-import { useFetchCourseInfo } from "~/app/api/course";
+import { useFetchCourseInfo, useFetchCourseRequisites } from "~/app/api/course";
 import ReqTreeCard from "./ReqTreeCard";
 
 type Props = {
@@ -14,8 +14,9 @@ type Props = {
 const CourseDetail = ({ courseID }: Props) => {
   const { data: { fces } = {} } = useFetchFCEInfoByCourse(courseID);
   const { data: info } = useFetchCourseInfo(courseID);
+  const { data: requisites } = useFetchCourseRequisites(courseID);
 
-  if (!info) {
+  if (!info || !requisites) {
     return <div>Loading...</div>;
   }
 
@@ -29,12 +30,13 @@ const CourseDetail = ({ courseID }: Props) => {
           scheduleInfos={filterSessions([...info.schedules]).sort(compareSessions)}
         />
       )}
-      {info.prereqs && info.postreqs && (
+      {info.prereqs && requisites.prereqRelations && requisites.postreqs && (
         <ReqTreeCard
           courseID={courseID}
           prereqs={info.prereqs}
-          postreqs={info.postreqs}
-          coreqs={info.coreqs} // Ensure coreqs are passed here
+          prereqRelations={requisites.prereqRelations}
+          postreqs={requisites.postreqs}
+          coreqs={info.coreqs}
         />
       )}
     </div>

--- a/apps/frontend/src/components/CourseDetail.tsx
+++ b/apps/frontend/src/components/CourseDetail.tsx
@@ -5,7 +5,7 @@ import { useFetchFCEInfoByCourse } from "~/app/api/fce";
 import { SchedulesCard } from "./SchedulesCard";
 import { FCECard } from "./FCECard";
 import { useFetchCourseInfo } from "~/app/api/course";
-import { ReqTreeCard } from "./ReqTreeCard";
+import ReqTreeCard from "./ReqTreeCard";
 
 type Props = {
   courseID: string;
@@ -13,22 +13,33 @@ type Props = {
 
 const CourseDetail = ({ courseID }: Props) => {
   const { data: { fces } = {} } = useFetchFCEInfoByCourse(courseID);
-  const { data: { schedules } = {} } = useFetchCourseInfo(courseID);
+  const { data: info } = useFetchCourseInfo(courseID);
+
+  if (!info) {
+    return <div>Loading...</div>;
+  }
 
   return (
     <div className="m-auto space-y-4 p-6">
       <CourseCard courseID={courseID} showFCEs={false} showCourseInfo={true} />
+      
       {fces && <FCECard fces={fces} />}
-      {schedules && (
+
+      {info.schedules && (
         <SchedulesCard
-          scheduleInfos={filterSessions([...schedules]).sort(compareSessions)}
+          scheduleInfos={filterSessions([...info.schedules]).sort(compareSessions)}
         />
       )}
-      {< ReqTreeCard courseID={courseID} />}
+
+      {info.prereqs && info.postreqs && (
+        <ReqTreeCard
+          courseID={courseID}
+          prereqs={info.prereqs}
+          postreqs={info.postreqs}
+        />
+      )}
     </div>
   );
 };
-
-// Add the inputs/logic above inside {<ReqTreeCard> } (if no post/pre-requisites, display "No pre/poste-requisites" or similar)
 
 export default CourseDetail;

--- a/apps/frontend/src/components/CourseDetail.tsx
+++ b/apps/frontend/src/components/CourseDetail.tsx
@@ -23,7 +23,6 @@ const CourseDetail = ({ courseID }: Props) => {
   return (
     <div className="m-auto space-y-4 p-6">
       <CourseCard courseID={courseID} showFCEs={false} showCourseInfo={true} />
-      
       {fces && <FCECard fces={fces} />}
       {info.schedules && (
         <SchedulesCard

--- a/apps/frontend/src/components/PostReqCourses.tsx
+++ b/apps/frontend/src/components/PostReqCourses.tsx
@@ -21,23 +21,57 @@ export const PostReqCourses = ({ courseID }: Props) => {
   // Recursive function to render only the child branches
   const renderTree = (nodes: TreeNode[]) => {
     return (
-      <div style={{ display: "flex", flexDirection: "column", marginLeft: "20px" }}>
+      <div style={{ display: "flex", flexDirection: "column" }}>
         {nodes.map((node) => (
           <div
             key={node.courseID}
             style={{
               display: "flex",
               alignItems: "center",
-              marginBottom: "10px",
             }}
           >
+
+            {/* Half vertical line for the first prereq in the list */}
+            {nodes && nodes.length > 1 && nodes.indexOf(node) === 0 && (
+              <div
+                style={{
+                  width: "1px",
+                  height: "20px",
+                  backgroundColor: "#d1d5db",
+                  marginTop: "20px",
+                }}
+              ></div>
+            )}
+
+            {/* Normal vertical Line connector */}
+            {nodes && nodes.length > 1 && nodes.indexOf(node) !== 0 && nodes.indexOf(node) !== nodes.length - 1 && (
+              <div
+                style={{
+                  width: "1px",
+                  backgroundColor: "#d1d5db",
+                  alignSelf: "stretch",
+                }}
+              ></div>
+            )}
+
+            {/* Half vertical line for the last prereq in the list */}
+            {nodes && nodes.length > 1 && nodes.indexOf(node) === nodes.length - 1 && (
+              <div
+                style={{
+                  width: "1px",
+                  height: "20px",
+                  backgroundColor: "#d1d5db",
+                  marginBottom: "20px",
+                }}
+              ></div>
+            )}
+
             {/* Line connector */}
             <div
               style={{
                 width: "20px",
                 height: "1px",
                 backgroundColor: "#d1d5db",
-                marginRight: "10px",
               }}
             ></div>
 
@@ -58,6 +92,8 @@ export const PostReqCourses = ({ courseID }: Props) => {
                 textDecoration: "none",
                 minWidth: "100px", // Ensure consistent width
                 display: "inline-block",
+                marginTop: "2px",
+                marginBottom: "2px",
               }}
             >
               {node.courseID}
@@ -87,7 +123,6 @@ export const PostReqCourses = ({ courseID }: Props) => {
             color: "#000000",
             textAlign: "center",
             fontSize: "14px",
-            marginTop: "-10px",
             fontWeight: "bold",
           }}
         >

--- a/apps/frontend/src/components/PostReqCourses.tsx
+++ b/apps/frontend/src/components/PostReqCourses.tsx
@@ -42,13 +42,13 @@ export const PostReqCourses = ({ courseID }: Props) => {
 
             {/* Line left to node */}
             {nodes && nodes.length > 1 && (
-            <div className="w-3 h-0.5 bg-gray-400"></div>
+              <div className="w-3 h-0.5 bg-gray-400"></div>
             )}
 
             {/* Course ID button */}
             <button
               onClick={() => window.location.href = `/course/${node.courseID}`}
-              className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
+              className="font-normal text-center px-2 py-1 text-base bg-gray-50 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
             >
               {node.courseID}
             </button>
@@ -71,10 +71,11 @@ export const PostReqCourses = ({ courseID }: Props) => {
       {childNodes.length > 0 ? (
         renderTree(childNodes)
       ) : (
-        <div className="italic ml-2 text-[#000000] text-center text-base font-bold">
-          No more post-reqs
+        <div
+          className="italic ml-2 text-gray-700 text-center text-lg font-semibold rounded-md"
+        >
+          None
         </div>
-
       )}
     </div>
   );

--- a/apps/frontend/src/components/PostReqCourses.tsx
+++ b/apps/frontend/src/components/PostReqCourses.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import Link from "next/link"; // Import Next.js Link component
+import { useFetchCourseInfo } from "~/app/api/course";
+
+interface TreeNode {
+  courseID: string;
+  postreqs?: TreeNode[];
+}
+
+interface Props {
+  courseID: string;
+}
+
+export const PostReqCourses = ({ courseID }: Props) => {
+  const { isPending: isCourseInfoPending, data: info } = useFetchCourseInfo(courseID);
+
+  if (isCourseInfoPending || !info) {
+    return null;
+  }
+
+  // Recursive function to render only the child branches
+  const renderTree = (nodes: TreeNode[]) => {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", marginLeft: "20px" }}>
+        {nodes.map((node) => (
+          <div
+            key={node.courseID}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              marginBottom: "10px",
+            }}
+          >
+            {/* Line connector */}
+            <div
+              style={{
+                width: "20px",
+                height: "1px",
+                backgroundColor: "#d1d5db",
+                marginRight: "10px",
+              }}
+            ></div>
+
+            {/* Course ID button */}
+            <button
+              onClick={() => window.location.href = `/course/${node.courseID}`}
+              style={{
+                fontWeight: "normal",
+                textAlign: "center",
+                padding: "5px 10px",
+                fontSize: "14px",
+                backgroundColor: "#f9fafb",
+                color: "#111827",
+                border: "1px solid #d1d5db",
+                borderRadius: "4px",
+                boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
+                cursor: "pointer",
+                textDecoration: "none",
+                minWidth: "100px", // Ensure consistent width
+                display: "inline-block",
+              }}
+            >
+              {node.courseID}
+            </button>
+
+            {/* Render child nodes recursively */}
+            {node.postreqs && renderTree(node.postreqs)}
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  // Transform fetched data into a tree structure excluding the parent node
+  const childNodes: TreeNode[] = info.postreqs?.map((postreq: string) => ({
+    courseID: postreq,
+  })) || [];
+
+  return (
+    <div>
+      {childNodes.length > 0 ? (
+        renderTree(childNodes)
+      ) : (
+        <div
+          style={{
+            fontStyle: "italic",
+            color: "#000000",
+            textAlign: "center",
+            fontSize: "14px",
+            marginTop: "-10px",
+            fontWeight: "bold",
+          }}
+        >
+          No further post-requisites
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PostReqCourses;

--- a/apps/frontend/src/components/PostReqCourses.tsx
+++ b/apps/frontend/src/components/PostReqCourses.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Link from "next/link"; // Import Next.js Link component
+import Link from "next/link"; 
 import { useFetchCourseInfo } from "~/app/api/course";
 
 interface TreeNode {
@@ -21,80 +21,31 @@ export const PostReqCourses = ({ courseID }: Props) => {
   // Recursive function to render only the child branches
   const renderTree = (nodes: TreeNode[]) => {
     return (
-      <div style={{ display: "flex", flexDirection: "column" }}>
+      <div className="flex flex-col">
         {nodes.map((node) => (
-          <div
-            key={node.courseID}
-            style={{
-              display: "flex",
-              alignItems: "center",
-            }}
-          >
-
+          <div key={node.courseID} className="flex items-center">
             {/* Half vertical line for the first prereq in the list */}
             {nodes && nodes.length > 1 && nodes.indexOf(node) === 0 && (
-              <div
-                style={{
-                  width: "1px",
-                  height: "20px",
-                  backgroundColor: "#d1d5db",
-                  marginTop: "20px",
-                }}
-              ></div>
+              <div className="w-[1px] h-[20px] bg-[#d1d5db] mt-[20px]"></div>
             )}
 
             {/* Normal vertical Line connector */}
             {nodes && nodes.length > 1 && nodes.indexOf(node) !== 0 && nodes.indexOf(node) !== nodes.length - 1 && (
-              <div
-                style={{
-                  width: "1px",
-                  backgroundColor: "#d1d5db",
-                  alignSelf: "stretch",
-                }}
-              ></div>
+              <div className="w-[1px] bg-[#d1d5db] self-stretch"></div>
             )}
 
             {/* Half vertical line for the last prereq in the list */}
             {nodes && nodes.length > 1 && nodes.indexOf(node) === nodes.length - 1 && (
-              <div
-                style={{
-                  width: "1px",
-                  height: "20px",
-                  backgroundColor: "#d1d5db",
-                  marginBottom: "20px",
-                }}
-              ></div>
+              <div className="w-[1px] h-[20px] bg-[#d1d5db] mb-[20px]"></div>
             )}
 
             {/* Line connector */}
-            <div
-              style={{
-                width: "20px",
-                height: "1px",
-                backgroundColor: "#d1d5db",
-              }}
-            ></div>
+            <div className="w-[20px] h-[1px] bg-[#d1d5db]"></div>
 
             {/* Course ID button */}
             <button
               onClick={() => window.location.href = `/course/${node.courseID}`}
-              style={{
-                fontWeight: "normal",
-                textAlign: "center",
-                padding: "5px 10px",
-                fontSize: "14px",
-                backgroundColor: "#f9fafb",
-                color: "#111827",
-                border: "1px solid #d1d5db",
-                borderRadius: "4px",
-                boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
-                cursor: "pointer",
-                textDecoration: "none",
-                minWidth: "100px", // Ensure consistent width
-                display: "inline-block",
-                marginTop: "2px",
-                marginBottom: "2px",
-              }}
+              className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
             >
               {node.courseID}
             </button>
@@ -117,17 +68,10 @@ export const PostReqCourses = ({ courseID }: Props) => {
       {childNodes.length > 0 ? (
         renderTree(childNodes)
       ) : (
-        <div
-          style={{
-            fontStyle: "italic",
-            color: "#000000",
-            textAlign: "center",
-            fontSize: "14px",
-            fontWeight: "bold",
-          }}
-        >
+        <div className="italic text-[#000000] text-center text-base font-bold">
           No further post-requisites
         </div>
+
       )}
     </div>
   );

--- a/apps/frontend/src/components/PostReqCourses.tsx
+++ b/apps/frontend/src/components/PostReqCourses.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { useFetchCourseRequisites } from "~/app/api/course";
-
-interface TreeNode {
-  courseID: string;
-  postreqs?: TreeNode[];
-}
+import { TreeNode } from "~/app/types";
 
 interface Props {
   courseID: string;

--- a/apps/frontend/src/components/PostReqCourses.tsx
+++ b/apps/frontend/src/components/PostReqCourses.tsx
@@ -72,7 +72,7 @@ export const PostReqCourses = ({ courseID }: Props) => {
         renderTree(childNodes)
       ) : (
         <div className="italic ml-2 text-[#000000] text-center text-base font-bold">
-          No further post-requisites
+          No more post-reqs
         </div>
 
       )}

--- a/apps/frontend/src/components/PostReqCourses.tsx
+++ b/apps/frontend/src/components/PostReqCourses.tsx
@@ -23,23 +23,31 @@ export const PostReqCourses = ({ courseID }: Props) => {
       <div className="flex flex-col">
         {nodes.map((node) => (
           <div key={node.courseID} className="flex items-center">
-            {/* Half vertical line for the first prereq in the list */}
+            {/* Half vertical line for the first postreq */}
             {nodes && nodes.length > 1 && nodes.indexOf(node) === 0 && (
-              <div className="w-[1px] h-[20px] bg-[#d1d5db] mt-[20px]"></div>
+              <div className="flex flex-col w-0.5 self-stretch">
+                <div className="h-1/2 self-stretch"></div>
+                <div className="w-0.5 h-1/2 bg-gray-400 self-stretch"></div>
+              </div>
             )}
 
             {/* Normal vertical Line connector */}
             {nodes && nodes.length > 1 && nodes.indexOf(node) !== 0 && nodes.indexOf(node) !== nodes.length - 1 && (
-              <div className="w-[1px] bg-[#d1d5db] self-stretch"></div>
+              <div className="w-0.5 bg-gray-400 self-stretch"></div>
             )}
 
             {/* Half vertical line for the last prereq in the list */}
             {nodes && nodes.length > 1 && nodes.indexOf(node) === nodes.length - 1 && (
-              <div className="w-[1px] h-[20px] bg-[#d1d5db] mb-[20px]"></div>
+              <div className="flex flex-col w-0.5 self-stretch">
+                <div className="w-0.5 h-1/2 bg-gray-400 self-stretch"></div>
+                <div className="h-1/2 self-stretch"></div>
+              </div>
             )}
 
-            {/* Line connector */}
-            <div className="w-[20px] h-[1px] bg-[#d1d5db]"></div>
+            {/* Line left to node */}
+            {nodes && nodes.length > 1 && (
+            <div className="w-3 h-0.5 bg-gray-400"></div>
+            )}
 
             {/* Course ID button */}
             <button
@@ -67,7 +75,7 @@ export const PostReqCourses = ({ courseID }: Props) => {
       {childNodes.length > 0 ? (
         renderTree(childNodes)
       ) : (
-        <div className="italic text-[#000000] text-center text-base font-bold">
+        <div className="italic ml-2 text-[#000000] text-center text-base font-bold">
           No further post-requisites
         </div>
 

--- a/apps/frontend/src/components/PostReqCourses.tsx
+++ b/apps/frontend/src/components/PostReqCourses.tsx
@@ -48,7 +48,7 @@ export const PostReqCourses = ({ courseID }: Props) => {
             {/* Course ID button */}
             <button
               onClick={() => window.location.href = `/course/${node.courseID}`}
-              className="font-normal text-center px-2 py-1 text-base bg-gray-50 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
+              className="font-normal text-center px-2 py-1 text-base bg-gray-50 hover:bg-gray-200 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
             >
               {node.courseID}
             </button>

--- a/apps/frontend/src/components/PostReqCourses.tsx
+++ b/apps/frontend/src/components/PostReqCourses.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import Link from "next/link"; 
-import { useFetchCourseInfo } from "~/app/api/course";
+import { useFetchCourseRequisites } from "~/app/api/course";
 
 interface TreeNode {
   courseID: string;
@@ -12,9 +11,9 @@ interface Props {
 }
 
 export const PostReqCourses = ({ courseID }: Props) => {
-  const { isPending: isCourseInfoPending, data: info } = useFetchCourseInfo(courseID);
+  const { isPending: isCourseInfoPending, data: requisites } = useFetchCourseRequisites(courseID);
 
-  if (isCourseInfoPending || !info) {
+  if (isCourseInfoPending || !requisites) {
     return null;
   }
 
@@ -59,7 +58,7 @@ export const PostReqCourses = ({ courseID }: Props) => {
   };
 
   // Transform fetched data into a tree structure excluding the parent node
-  const childNodes: TreeNode[] = info.postreqs?.map((postreq: string) => ({
+  const childNodes: TreeNode[] = requisites.postreqs?.map((postreq: string) => ({
     courseID: postreq,
   })) || [];
 

--- a/apps/frontend/src/components/PostReqCourses.tsx
+++ b/apps/frontend/src/components/PostReqCourses.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useFetchCourseRequisites } from "~/app/api/course";
 import { TreeNode } from "~/app/types";
+import { CourseIDButton } from "./Buttons";
 
 interface Props {
   courseID: string;
@@ -46,12 +47,7 @@ export const PostReqCourses = ({ courseID }: Props) => {
             )}
 
             {/* Course ID button */}
-            <button
-              onClick={() => window.location.href = `/course/${node.courseID}`}
-              className="font-normal text-center px-2 py-1 text-base bg-gray-50 hover:bg-gray-200 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
-            >
-              {node.courseID}
-            </button>
+            <CourseIDButton courseID={node.courseID} />
 
             {/* Render child nodes recursively */}
             {node.postreqs && renderTree(node.postreqs)}

--- a/apps/frontend/src/components/PreReqCourses.tsx
+++ b/apps/frontend/src/components/PreReqCourses.tsx
@@ -20,81 +20,33 @@ export const PreReqCourses = ({ courseID }: Props) => {
   // Recursive function to render only the child branches
   const renderTree = (nodes: TreeNode[]) => {
     return (
-      <div style={{ display: "flex", flexDirection: "column" }}>
+      <div className="flex flex-col">
         {nodes.map((node) => (
-          <div
-            key={node.courseID}
-            style={{
-              display: "flex",
-              alignItems: "center",
-            }}
-          >
+          <div key={node.courseID} className="flex items-center">
             {/* Course ID button */}
             <button
-              onClick={() => window.location.href = `/course/${node.courseID}`}
-              style={{
-                fontWeight: "normal",
-                textAlign: "center",
-                padding: "5px 10px",
-                fontSize: "14px",
-                backgroundColor: "#f9fafb",
-                color: "#111827",
-                border: "1px solid #d1d5db",
-                borderRadius: "4px",
-                boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
-                cursor: "pointer",
-                textDecoration: "none",
-                minWidth: "100px", // Ensure consistent width
-                display: "inline-block",
-                marginTop: "2px",
-                marginBottom: "2px",
-              }}
+            onClick={() => (window.location.href = `/course/${node.courseID}`)}
+            className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
             >
               {node.courseID}
             </button>
 
             {/* Line connector */}
-            <div
-              style={{
-                width: "20px",
-                height: "1px",
-                backgroundColor: "#d1d5db",
-              }}
-            ></div>
+            <div className="w-[20px] h-[1px] bg-[#d1d5db]"></div>
 
             {/* Half vertical line for the first prereq in the list */}
             {nodes && nodes.length > 1 && nodes.indexOf(node) === 0 && (
-              <div
-                style={{
-                  width: "1px",
-                  height: "20px",
-                  backgroundColor: "#d1d5db",
-                  marginTop: "20px",
-                }}
-              ></div>
+              <div className="w-[1px] h-[20px] bg-[#d1d5db] mt-[20px]"></div>
             )}
 
             {/* Normal vertical Line connector */}
             {nodes && nodes.length > 1 && nodes.indexOf(node) !== 0 && nodes.indexOf(node) !== nodes.length - 1 && (
-              <div
-                style={{
-                  width: "1px",
-                  backgroundColor: "#d1d5db",
-                  alignSelf: "stretch",
-                }}
-              ></div>
+              <div className="w-[1px] bg-[#d1d5db] self-stretch"></div>
             )}
 
             {/* Half vertical line for the last prereq in the list */}
             {nodes && nodes.length > 1 && nodes.indexOf(node) === nodes.length - 1 && (
-              <div
-                style={{
-                  width: "1px",
-                  height: "20px",
-                  backgroundColor: "#d1d5db",
-                  marginBottom: "20px",
-                }}
-              ></div>
+              <div className="w-[1px] h-[20px] bg-[#d1d5db] mb-[20px]"></div>
             )}
 
             {/* Render child nodes recursively */}
@@ -115,15 +67,7 @@ export const PreReqCourses = ({ courseID }: Props) => {
       {childNodes.length > 0 ? (
         renderTree(childNodes)
       ) : (
-        <div
-          style={{
-            fontStyle: "italic",
-            color: "#000000",
-            textAlign: "center",
-            fontSize: "14px",
-            fontWeight: "bold",
-          }}
-        >
+        <div className="italic text-[#000000] text-center text-base font-bold">
           No further prerequisites
         </div>
       )}

--- a/apps/frontend/src/components/PreReqCourses.tsx
+++ b/apps/frontend/src/components/PreReqCourses.tsx
@@ -31,16 +31,6 @@ export const PreReqCourses = ({ courseID }: Props) => {
               marginBottom: "10px",
             }}
           >
-            {/* Line connector */}
-            <div
-              style={{
-                width: "20px",
-                height: "1px",
-                backgroundColor: "#d1d5db",
-                marginRight: "10px",
-              }}
-            ></div>
-
             {/* Course ID button */}
             <button
               onClick={() => window.location.href = `/course/${node.courseID}`}
@@ -58,10 +48,21 @@ export const PreReqCourses = ({ courseID }: Props) => {
                 textDecoration: "none",
                 minWidth: "100px", // Ensure consistent width
                 display: "inline-block",
+                marginRight: "10px", // Adjust spacing for line placement
               }}
             >
               {node.courseID}
             </button>
+
+            {/* Line connector */}
+            <div
+              style={{
+                width: "20px",
+                height: "1px",
+                backgroundColor: "#d1d5db",
+                marginRight: "-10px", // Align the line to the green position
+              }}
+            ></div>
 
             {/* Render child nodes recursively */}
             {node.prereqs && renderTree(node.prereqs)}

--- a/apps/frontend/src/components/PreReqCourses.tsx
+++ b/apps/frontend/src/components/PreReqCourses.tsx
@@ -1,11 +1,6 @@
 import React from "react";
 import { useFetchCourseRequisites } from "~/app/api/course";
-
-interface TreeNode {
-  courseID: string;
-  prereqs?: TreeNode[];
-  prereqRelations?: TreeNode[][];
-}
+import { TreeNode } from "~/app/types";
 
 interface Props {
   courseID: string;

--- a/apps/frontend/src/components/PreReqCourses.tsx
+++ b/apps/frontend/src/components/PreReqCourses.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { useFetchCourseInfo } from "~/app/api/course";
+import { useFetchCourseRequisites } from "~/app/api/course";
 
 interface TreeNode {
   courseID: string;
   prereqs?: TreeNode[];
+  prereqRelations?: TreeNode[][];
 }
 
 interface Props {
@@ -11,11 +12,12 @@ interface Props {
 }
 
 export const PreReqCourses = ({ courseID }: Props) => {
-  const { isPending: isCourseInfoPending, data: info } = useFetchCourseInfo(courseID);
+  const { isPending: isCourseInfoPending, data: requisites } = useFetchCourseRequisites(courseID);
 
-  if (isCourseInfoPending || !info) {
+  if (isCourseInfoPending || !requisites) {
     return null;
   }
+
 
   // Recursive function to render only the child branches
   const renderTree = (nodes: TreeNode[]) => {
@@ -58,7 +60,10 @@ export const PreReqCourses = ({ courseID }: Props) => {
   };
 
   // Transform fetched data into a tree structure excluding the parent node
-  const childNodes: TreeNode[] = info.prereqs?.map((prereq: string) => ({
+
+  const prereqs = requisites.prereqRelations?.flat()
+
+  const childNodes: TreeNode[] = prereqs.map((prereq: string) => ({
     courseID: prereq,
   })) || [];
 

--- a/apps/frontend/src/components/PreReqCourses.tsx
+++ b/apps/frontend/src/components/PreReqCourses.tsx
@@ -72,7 +72,7 @@ export const PreReqCourses = ({ courseID }: Props) => {
         renderTree(childNodes)
       ) : (
         <div className="italic text-center text-base font-bold mr-2">
-          No further pre-requisites
+          No more pre-reqs
         </div>
       )}
     </div>

--- a/apps/frontend/src/components/PreReqCourses.tsx
+++ b/apps/frontend/src/components/PreReqCourses.tsx
@@ -4,14 +4,14 @@ import { useFetchCourseInfo } from "~/app/api/course";
 
 interface TreeNode {
   courseID: string;
-  postreqs?: TreeNode[];
+  prereqs?: TreeNode[];
 }
 
 interface Props {
   courseID: string;
 }
 
-export const PostReqCourses = ({ courseID }: Props) => {
+export const PreReqCourses = ({ courseID }: Props) => {
   const { isPending: isCourseInfoPending, data: info } = useFetchCourseInfo(courseID);
 
   if (isCourseInfoPending || !info) {
@@ -64,7 +64,7 @@ export const PostReqCourses = ({ courseID }: Props) => {
             </button>
 
             {/* Render child nodes recursively */}
-            {node.postreqs && renderTree(node.postreqs)}
+            {node.prereqs && renderTree(node.prereqs)}
           </div>
         ))}
       </div>
@@ -72,8 +72,8 @@ export const PostReqCourses = ({ courseID }: Props) => {
   };
 
   // Transform fetched data into a tree structure excluding the parent node
-  const childNodes: TreeNode[] = info.postreqs?.map((postreq: string) => ({
-    courseID: postreq,
+  const childNodes: TreeNode[] = info.prereqs?.map((prereq: string) => ({
+    courseID: prereq,
   })) || [];
 
   return (
@@ -91,11 +91,11 @@ export const PostReqCourses = ({ courseID }: Props) => {
             fontWeight: "bold",
           }}
         >
-          No further post-requisites
+          No further prerequisites
         </div>
       )}
     </div>
   );
 };
 
-export default PostReqCourses;
+export default PreReqCourses;

--- a/apps/frontend/src/components/PreReqCourses.tsx
+++ b/apps/frontend/src/components/PreReqCourses.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Link from "next/link"; // Import Next.js Link component
 import { useFetchCourseInfo } from "~/app/api/course";
 
 interface TreeNode {
@@ -21,14 +20,13 @@ export const PreReqCourses = ({ courseID }: Props) => {
   // Recursive function to render only the child branches
   const renderTree = (nodes: TreeNode[]) => {
     return (
-      <div style={{ display: "flex", flexDirection: "column", marginLeft: "20px" }}>
+      <div style={{ display: "flex", flexDirection: "column" }}>
         {nodes.map((node) => (
           <div
             key={node.courseID}
             style={{
               display: "flex",
               alignItems: "center",
-              marginBottom: "10px",
             }}
           >
             {/* Course ID button */}
@@ -48,7 +46,8 @@ export const PreReqCourses = ({ courseID }: Props) => {
                 textDecoration: "none",
                 minWidth: "100px", // Ensure consistent width
                 display: "inline-block",
-                marginRight: "10px", // Adjust spacing for line placement
+                marginTop: "2px",
+                marginBottom: "2px",
               }}
             >
               {node.courseID}
@@ -60,9 +59,43 @@ export const PreReqCourses = ({ courseID }: Props) => {
                 width: "20px",
                 height: "1px",
                 backgroundColor: "#d1d5db",
-                marginRight: "-10px", // Align the line to the green position
               }}
             ></div>
+
+            {/* Half vertical line for the first prereq in the list */}
+            {nodes && nodes.length > 1 && nodes.indexOf(node) === 0 && (
+              <div
+                style={{
+                  width: "1px",
+                  height: "20px",
+                  backgroundColor: "#d1d5db",
+                  marginTop: "20px",
+                }}
+              ></div>
+            )}
+
+            {/* Normal vertical Line connector */}
+            {nodes && nodes.length > 1 && nodes.indexOf(node) !== 0 && nodes.indexOf(node) !== nodes.length - 1 && (
+              <div
+                style={{
+                  width: "1px",
+                  backgroundColor: "#d1d5db",
+                  alignSelf: "stretch",
+                }}
+              ></div>
+            )}
+
+            {/* Half vertical line for the last prereq in the list */}
+            {nodes && nodes.length > 1 && nodes.indexOf(node) === nodes.length - 1 && (
+              <div
+                style={{
+                  width: "1px",
+                  height: "20px",
+                  backgroundColor: "#d1d5db",
+                  marginBottom: "20px",
+                }}
+              ></div>
+            )}
 
             {/* Render child nodes recursively */}
             {node.prereqs && renderTree(node.prereqs)}
@@ -88,7 +121,6 @@ export const PreReqCourses = ({ courseID }: Props) => {
             color: "#000000",
             textAlign: "center",
             fontSize: "14px",
-            marginTop: "-10px",
             fontWeight: "bold",
           }}
         >

--- a/apps/frontend/src/components/PreReqCourses.tsx
+++ b/apps/frontend/src/components/PreReqCourses.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useFetchCourseRequisites } from "~/app/api/course";
 import { TreeNode } from "~/app/types";
+import { CourseIDButton } from "./Buttons";
 
 interface Props {
   courseID: string;
@@ -20,12 +21,7 @@ export const PreReqCourses = ({ courseID }: Props) => {
         {nodes.map((node) => (
           <div key={node.courseID} className="flex items-center">
             {/* Course ID button */}
-            <button
-              onClick={() => (window.location.href = `/course/${node.courseID}`)}
-              className="font-normal text-center px-2 py-1 text-base bg-gray-50 hover:bg-gray-200 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
-            >
-              {node.courseID}
-            </button>
+            <CourseIDButton courseID={node.courseID} />
 
             {/* Line connector right to node */}
             {nodes && nodes.length > 1 && (

--- a/apps/frontend/src/components/PreReqCourses.tsx
+++ b/apps/frontend/src/components/PreReqCourses.tsx
@@ -18,7 +18,6 @@ export const PreReqCourses = ({ courseID }: Props) => {
     return null;
   }
 
-
   // Recursive function to render only the child branches
   const renderTree = (nodes: TreeNode[]) => {
     return (
@@ -27,28 +26,36 @@ export const PreReqCourses = ({ courseID }: Props) => {
           <div key={node.courseID} className="flex items-center">
             {/* Course ID button */}
             <button
-            onClick={() => (window.location.href = `/course/${node.courseID}`)}
-            className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
+              onClick={() => (window.location.href = `/course/${node.courseID}`)}
+              className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
             >
               {node.courseID}
             </button>
 
-            {/* Line connector */}
-            <div className="w-[20px] h-[1px] bg-[#d1d5db]"></div>
+            {/* Line connector right to node */}
+            {nodes && nodes.length > 1 && (
+              <div className="w-3 h-0.5 bg-gray-400"></div>
+            )}
 
             {/* Half vertical line for the first prereq in the list */}
             {nodes && nodes.length > 1 && nodes.indexOf(node) === 0 && (
-              <div className="w-[1px] h-[20px] bg-[#d1d5db] mt-[20px]"></div>
+              <div className="flex flex-col w-0.5 self-stretch">
+                <div className="h-1/2 self-stretch"></div>
+                <div className="w-0.5 h-1/2 bg-gray-400 self-stretch"></div>
+              </div>
             )}
 
             {/* Normal vertical Line connector */}
             {nodes && nodes.length > 1 && nodes.indexOf(node) !== 0 && nodes.indexOf(node) !== nodes.length - 1 && (
-              <div className="w-[1px] bg-[#d1d5db] self-stretch"></div>
+              <div className="w-0.5 bg-gray-400 self-stretch"></div>
             )}
 
             {/* Half vertical line for the last prereq in the list */}
             {nodes && nodes.length > 1 && nodes.indexOf(node) === nodes.length - 1 && (
-              <div className="w-[1px] h-[20px] bg-[#d1d5db] mb-[20px]"></div>
+              <div className="flex flex-col w-0.5 self-stretch">
+                <div className="w-0.5 h-1/2 bg-gray-400 self-stretch"></div>
+                <div className="h-1/2 self-stretch"></div>
+              </div>
             )}
 
             {/* Render child nodes recursively */}
@@ -60,10 +67,7 @@ export const PreReqCourses = ({ courseID }: Props) => {
   };
 
   // Transform fetched data into a tree structure excluding the parent node
-
-  const prereqs = requisites.prereqRelations?.flat()
-
-  const childNodes: TreeNode[] = prereqs.map((prereq: string) => ({
+  const childNodes: TreeNode[] = requisites.prereqs.map((prereq: string) => ({
     courseID: prereq,
   })) || [];
 
@@ -72,8 +76,8 @@ export const PreReqCourses = ({ courseID }: Props) => {
       {childNodes.length > 0 ? (
         renderTree(childNodes)
       ) : (
-        <div className="italic text-[#000000] text-center text-base font-bold">
-          No further prerequisites
+        <div className="italic text-center text-base font-bold mr-2">
+          No further pre-requisites
         </div>
       )}
     </div>

--- a/apps/frontend/src/components/PreReqCourses.tsx
+++ b/apps/frontend/src/components/PreReqCourses.tsx
@@ -22,7 +22,7 @@ export const PreReqCourses = ({ courseID }: Props) => {
             {/* Course ID button */}
             <button
               onClick={() => (window.location.href = `/course/${node.courseID}`)}
-              className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
+              className="font-normal text-center px-2 py-1 text-base bg-gray-50 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
             >
               {node.courseID}
             </button>
@@ -71,8 +71,10 @@ export const PreReqCourses = ({ courseID }: Props) => {
       {childNodes.length > 0 ? (
         renderTree(childNodes)
       ) : (
-        <div className="italic text-center text-base font-bold mr-2">
-          No more pre-reqs
+        <div
+          className="italic mr-2 text-gray-700 text-center text-lg font-semibold rounded-md"
+        >
+          None
         </div>
       )}
     </div>

--- a/apps/frontend/src/components/PreReqCourses.tsx
+++ b/apps/frontend/src/components/PreReqCourses.tsx
@@ -22,7 +22,7 @@ export const PreReqCourses = ({ courseID }: Props) => {
             {/* Course ID button */}
             <button
               onClick={() => (window.location.href = `/course/${node.courseID}`)}
-              className="font-normal text-center px-2 py-1 text-base bg-gray-50 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
+              className="font-normal text-center px-2 py-1 text-base bg-gray-50 hover:bg-gray-200 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
             >
               {node.courseID}
             </button>

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -4,8 +4,8 @@ import React from "react";
 export const ReqTreeCard = () => { //add any inputs here
     return (
       <Card>
-        <Card.Header>Prerequisite, Corequisite, and Postrequisite Tree</Card.Header>
+        <Card.Header>Pre/Co/Post-requisite Tree</Card.Header>
       </Card>
     );
   };
-  // Add the tree logic
+  // Add the tree logic or call the tree component within the <Card> tag (look at FCECard.tsx as an example)

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -1,37 +1,46 @@
-import {
-  courseListToString,
-  injectLinks,
-} from "~/app/utils";
+import React from "react";
 import { Card } from "./Card";
-import { useFetchCourseInfo } from "~/app/api/course";
+import ReqTreeDetail from "./ReqTreeDetail";
 
-interface Props {
+interface TreeNode {
   courseID: string;
+  prereqs?: TreeNode[];
+  postreqs?: TreeNode[];
 }
 
-export const ReqTreeCard = ({
-  courseID
-}: Props) => { //add any inputs here (courses, prereqs, etc.)
-  const { isPending: isCourseInfoPending, data: info } = useFetchCourseInfo(courseID);
+interface ReqTreeCardProps {
+  courseID: string;
+  prereqs: string[];    // Array of prerequisite course IDs
+  postreqs: string[];   // Array of postrequisite course IDs
+}
 
-  if (isCourseInfoPending || !info) {
-    return (<></>);
-  }
+const ReqTreeCard: React.FC<ReqTreeCardProps> = ({ courseID, prereqs, postreqs }) => {
+  // Check if there are no prerequisites and no postrequisites
+  const hasNoRequisites = prereqs.length === 0 && postreqs.length === 0;
+
+  // Build the requisite tree with prereqs and postreqs
+  const buildTree = (id: string, prereqList: string[], postreqList: string[]): TreeNode => {
+    return {
+      courseID: id,
+      prereqs: prereqList.map((prereq) => ({ courseID: prereq })),
+      postreqs: postreqList.map((postreq) => ({ courseID: postreq })),
+    };
+  };
+
+  const tree = buildTree(courseID, prereqs, postreqs);
 
   return (
     <Card>
-      <Card.Header>Prerequisite, Corequisite, and Postrequisite Tree</Card.Header>
-      <div className="space-y-4">
-        <div className="flex flex-col">
-          <div className="font-semibold">
-            Postrequisites
-          </div>
-          <div className="text-md text-gray-500">
-            {injectLinks(courseListToString(info.postreqs))}
-          </div>
+      <Card.Header>Requisite Tree</Card.Header>
+      {hasNoRequisites ? (
+        <div style={{ fontStyle: "italic", color: "#6b7280", padding: "20px", textAlign: "center" }}>
+          There are no prerequisites or postrequisites for this course.
         </div>
-      </div>
+      ) : (
+        <ReqTreeDetail root={tree} />
+      )}
     </Card>
   );
 };
-// Add the tree logic or call the tree component within the <Card> tag (look at FCECard.tsx as an example)
+
+export default ReqTreeCard;

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -8,3 +8,4 @@ export const ReqTreeCard = () => { //add any inputs here
       </Card>
     );
   };
+  // Add the tree logic

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -1,11 +1,37 @@
+import {
+  courseListToString,
+  injectLinks,
+} from "~/app/utils";
 import { Card } from "./Card";
-import React from "react";
+import { useFetchCourseInfo } from "~/app/api/course";
 
-export const ReqTreeCard = () => { //add any inputs here (courses, prereqs, etc.)
-    return (
-      <Card>
-        <Card.Header>Prerequisite, Corequisite, and Postrequisite Tree</Card.Header>
-      </Card>
-    );
-  };
-  // Add the tree logic or call the tree component within the <Card> tag (look at FCECard.tsx as an example)
+interface Props {
+  courseID: string;
+}
+
+export const ReqTreeCard = ({
+  courseID
+}: Props) => { //add any inputs here (courses, prereqs, etc.)
+  const { isPending: isCourseInfoPending, data: info } = useFetchCourseInfo(courseID);
+
+  if (isCourseInfoPending || !info) {
+    return (<></>);
+  }
+
+  return (
+    <Card>
+      <Card.Header>Prerequisite, Corequisite, and Postrequisite Tree</Card.Header>
+      <div className="space-y-4">
+        <div className="flex flex-col">
+          <div className="font-semibold">
+            Postrequisites
+          </div>
+          <div className="text-md text-gray-500">
+            {injectLinks(courseListToString(info.postreqs))}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+};
+// Add the tree logic or call the tree component within the <Card> tag (look at FCECard.tsx as an example)

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -6,35 +6,36 @@ interface TreeNode {
   courseID: string;
   prereqs?: TreeNode[];
   postreqs?: TreeNode[];
+  coreqs?: Array<{ courseID: string }>; // Ensure coreqs are included
 }
 
 interface ReqTreeCardProps {
   courseID: string;
-  prereqs: string[];    // Array of prerequisite course IDs
-  postreqs: string[];   // Array of postrequisite course IDs
+  prereqs: string[];
+  postreqs: string[];
+  coreqs: string[]; // Ensure coreqs are included
 }
 
-const ReqTreeCard: React.FC<ReqTreeCardProps> = ({ courseID, prereqs, postreqs }) => {
-  // Check if there are no prerequisites and no postrequisites
-  const hasNoRequisites = prereqs.length === 0 && postreqs.length === 0;
+const ReqTreeCard: React.FC<ReqTreeCardProps> = ({ courseID, prereqs, postreqs, coreqs }) => {
+  const hasNoRequisites = prereqs.length === 0 && postreqs.length === 0 && coreqs.length === 0;
 
-  // Build the requisite tree with prereqs and postreqs
-  const buildTree = (id: string, prereqList: string[], postreqList: string[]): TreeNode => {
+  const buildTree = (id: string, prereqList: string[], postreqList: string[], coreqList: string[]): TreeNode => {
     return {
       courseID: id,
       prereqs: prereqList.map((prereq) => ({ courseID: prereq })),
       postreqs: postreqList.map((postreq) => ({ courseID: postreq })),
+      coreqs: coreqList.map((coreq) => ({ courseID: coreq })), // Ensure coreqs are included
     };
   };
 
-  const tree = buildTree(courseID, prereqs, postreqs);
+  const tree = buildTree(courseID, prereqs, postreqs, coreqs);
 
   return (
     <Card>
       <Card.Header>Requisite Tree</Card.Header>
       {hasNoRequisites ? (
         <div style={{ fontStyle: "italic", color: "#6b7280", padding: "20px", textAlign: "center" }}>
-          There are no prerequisites or postrequisites for this course.
+          There are no prerequisites, corequisites, or postrequisites for this course.
         </div>
       ) : (
         <ReqTreeDetail root={tree} />

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -4,7 +4,7 @@ import React from "react";
 export const ReqTreeCard = () => { //add any inputs here
     return (
       <Card>
-        <Card.Header>Pre/Co/Post-requisite Tree</Card.Header>
+        <Card.Header>Prerequisite, Corequisite, and Postrequisite Tree</Card.Header>
       </Card>
     );
   };

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -34,9 +34,9 @@ const ReqTreeCard: React.FC<ReqTreeCardProps> = ({ courseID, prereqs, postreqs, 
     <Card>
       <Card.Header>Requisite Tree</Card.Header>
       {hasNoRequisites ? (
-        <div style={{ fontStyle: "italic", color: "#6b7280", padding: "20px", textAlign: "center" }}>
+        <div className="italic text-[#6b7280] p-[20px] text-center">
           There are no prerequisites, corequisites, or postrequisites for this course.
-        </div>
+        </div>      
       ) : (
         <ReqTreeDetail root={tree} />
       )}

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -8,29 +8,27 @@ interface ReqTreeCardProps {
   prereqs: string[];
   prereqRelations: string[][];
   postreqs: string[];
-  coreqs: string[];
 }
 
-const ReqTreeCard: React.FC<ReqTreeCardProps> = ({ courseID, prereqs, prereqRelations, postreqs, coreqs }) => {
-  const hasNoRequisites = prereqs.length === 0 && postreqs.length === 0 && coreqs.length === 0;
+const ReqTreeCard: React.FC<ReqTreeCardProps> = ({ courseID, prereqs, prereqRelations, postreqs }) => {
+  const hasNoRequisites = prereqs.length === 0 && postreqs.length === 0;
 
-  const buildTree = (id: string, prereqList: string[], prereqRelationsList: string[][], postreqList: string[], coreqList: string[]): TreeNode => {
+  const buildTree = (id: string, prereqList: string[], prereqRelationsList: string[][], postreqList: string[]): TreeNode => {
     return {
       courseID: id,
       prereqs: prereqList.map((prereq) => ({ courseID: prereq })),
       prereqRelations: prereqRelationsList.map((prereqSubList) => (prereqSubList.map((prereq) => ({ courseID: prereq })))),
       postreqs: postreqList.map((postreq) => ({ courseID: postreq })),
-      coreqs: coreqList.map((coreq) => ({ courseID: coreq })),
     };
   };
 
-  const tree = buildTree(courseID, prereqs, prereqRelations, postreqs, coreqs);
+  const tree = buildTree(courseID, prereqs, prereqRelations, postreqs);
 
   return (
     <Card>
       <Card.Header>Requisite Tree</Card.Header>
       {hasNoRequisites ? (
-        <div className="italic text-[#6b7280] p-[20px] text-center">
+        <div className="italic text-gray-800 p-10 text-center">
           There are no prerequisites or postrequisites for this course.
         </div>
       ) : (

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -5,30 +5,33 @@ import ReqTreeDetail from "./ReqTreeDetail";
 interface TreeNode {
   courseID: string;
   prereqs?: TreeNode[];
+  prereqRelations?: TreeNode[][];
   postreqs?: TreeNode[];
-  coreqs?: Array<{ courseID: string }>; // Ensure coreqs are included
+  coreqs?: Array<{ courseID: string }>;
 }
 
 interface ReqTreeCardProps {
   courseID: string;
   prereqs: string[];
+  prereqRelations: string[][];
   postreqs: string[];
-  coreqs: string[]; // Ensure coreqs are included
+  coreqs: string[];
 }
 
-const ReqTreeCard: React.FC<ReqTreeCardProps> = ({ courseID, prereqs, postreqs, coreqs }) => {
+const ReqTreeCard: React.FC<ReqTreeCardProps> = ({ courseID, prereqs, prereqRelations, postreqs, coreqs }) => {
   const hasNoRequisites = prereqs.length === 0 && postreqs.length === 0 && coreqs.length === 0;
 
-  const buildTree = (id: string, prereqList: string[], postreqList: string[], coreqList: string[]): TreeNode => {
+  const buildTree = (id: string, prereqList: string[], prereqRelationsList: string[][], postreqList: string[], coreqList: string[]): TreeNode => {
     return {
       courseID: id,
       prereqs: prereqList.map((prereq) => ({ courseID: prereq })),
+      prereqRelations: prereqRelationsList.map((prereqSubList) => (prereqSubList.map((prereq) => ({ courseID: prereq })))),
       postreqs: postreqList.map((postreq) => ({ courseID: postreq })),
-      coreqs: coreqList.map((coreq) => ({ courseID: coreq })), // Ensure coreqs are included
+      coreqs: coreqList.map((coreq) => ({ courseID: coreq })),
     };
   };
 
-  const tree = buildTree(courseID, prereqs, postreqs, coreqs);
+  const tree = buildTree(courseID, prereqs, prereqRelations, postreqs, coreqs);
 
   return (
     <Card>

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -1,0 +1,10 @@
+import { Card } from "./Card";
+import React from "react";
+
+export const ReqTreeCard = () => { //add any inputs here
+    return (
+      <Card>
+        <Card.Header>Prerequisite, Corequisite, and Postrequisite Tree</Card.Header>
+      </Card>
+    );
+  };

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -39,6 +39,7 @@ const ReqTreeCard: React.FC<ReqTreeCardProps> = ({ courseID, prereqs, postreqs }
       ) : (
         <ReqTreeDetail root={tree} />
       )}
+
     </Card>
   );
 };

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -1,14 +1,7 @@
 import React from "react";
 import { Card } from "./Card";
 import ReqTreeDetail from "./ReqTreeDetail";
-
-interface TreeNode {
-  courseID: string;
-  prereqs?: TreeNode[];
-  prereqRelations?: TreeNode[][];
-  postreqs?: TreeNode[];
-  coreqs?: Array<{ courseID: string }>;
-}
+import { TreeNode } from "~/app/types";
 
 interface ReqTreeCardProps {
   courseID: string;

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -1,7 +1,7 @@
 import { Card } from "./Card";
 import React from "react";
 
-export const ReqTreeCard = () => { //add any inputs here
+export const ReqTreeCard = () => { //add any inputs here (courses, prereqs, etc.)
     return (
       <Card>
         <Card.Header>Prerequisite, Corequisite, and Postrequisite Tree</Card.Header>

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -31,8 +31,8 @@ const ReqTreeCard: React.FC<ReqTreeCardProps> = ({ courseID, prereqs, prereqRela
       <Card.Header>Requisite Tree</Card.Header>
       {hasNoRequisites ? (
         <div className="italic text-[#6b7280] p-[20px] text-center">
-          There are no prerequisites, corequisites, or postrequisites for this course.
-        </div>      
+          There are no prerequisites or postrequisites for this course.
+        </div>
       ) : (
         <ReqTreeDetail root={tree} />
       )}

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import Link from "next/link";
 import PostReqCourses from "./PostReqCourses";
 import PreReqCourses from "./PreReqCourses";
 import {
@@ -7,14 +6,7 @@ import {
   ChevronRightIcon,
 } from "@heroicons/react/20/solid";
 import { FlushedButton } from "./Buttons";
-
-interface TreeNode {
-  courseID: string;
-  coreqs?: Array<{ courseID: string }>;
-  prereqs?: TreeNode[];
-  prereqRelations?: TreeNode[][];
-  postreqs?: TreeNode[];
-}
+import { TreeNode } from "~/app/types";
 
 interface ReqTreeProps {
   root: TreeNode;
@@ -195,14 +187,10 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               )}
 
             </div>
-
           ))}
-
         </div>
       )}
-
     </div>
-
   );
 };
 

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -6,6 +6,7 @@ import {
   ChevronRightIcon,
 } from "@heroicons/react/20/solid";
 import { TreeNode } from "~/app/types";
+import { CourseIDButton } from "./Buttons";
 
 interface ReqTreeProps {
   root: TreeNode;
@@ -71,12 +72,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               <div className="w-3 h-0.5 bg-gray-400"></div>
 
               {/* Course ID button */}
-              <button
-                onClick={() => (window.location.href = `/course/${prereq.courseID}`)}
-                className="font-normal text-center px-2 py-1 text-base bg-gray-50 hover:bg-gray-200 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
-              >
-                {prereq.courseID}
-              </button>
+              <CourseIDButton courseID={prereq.courseID} />
 
               {/* Line connector right to node */}
               {root.prereqs && root.prereqs.length > 1 && (
@@ -118,7 +114,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
 
         {/* Main node */}
         <div
-          className="font-bold text-center px-2 py-1 text-base bg-gray-200 text-gray-900 border border-gray-400 rounded shadow-md min-w-[80px] mt-[10px] mb-[10px]"
+          className="font-bold text-center px-2 py-1 text-base bg-gray-200 text-gray-900 border border-gray-400 rounded shadow-md min-w-20"
         >
           {root.courseID}
         </div>
@@ -161,12 +157,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               )}
 
               {/* Course ID button */}
-              <button
-                onClick={() => (window.location.href = `/course/${postreq.courseID}`)}
-                className="font-normal text-center px-2 py-1 text-base bg-gray-50 hover:bg-gray-200 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
-              >
-                {postreq.courseID}
-              </button>
+              <CourseIDButton courseID={postreq.courseID} />
 
               {/* Line right to node */}
               <div className="w-3 h-0.5 bg-gray-400"></div>

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import Link from "next/link"; // Import Next.js Link component
+
+interface TreeNode {
+  courseID: string;
+  prereqs?: TreeNode[];
+  postreqs?: TreeNode[];
+}
+
+interface ReqTreeProps {
+  root: TreeNode;
+}
+
+const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
+  return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
+      
+      {/* Prerequisites on the Left */}
+      {root.prereqs && root.prereqs.length > 0 && (
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", marginRight: "20px" }}>
+          {root.prereqs.map((prereq) => (
+            <div key={prereq.courseID} style={{ display: "flex", alignItems: "center", marginBottom: "10px" }}>
+              <Link href={`/course/${prereq.courseID}`} passHref>
+                <div
+                  style={{
+                    fontWeight: "normal",
+                    textAlign: "center",
+                    padding: "5px 10px",
+                    fontSize: "14px",
+                    backgroundColor: "#f9fafb", 
+                    color: "#111827",
+                    border: "1px solid #d1d5db",
+                    borderRadius: "4px",
+                    boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
+                    cursor: "pointer",
+                  }}
+                >
+                  {prereq.courseID}
+                </div>
+              </Link>
+              <div
+                style={{
+                  width: "20px",
+                  height: "1px",
+                  backgroundColor: "#d1d5db",
+                  marginLeft: "5px",
+                }}
+              ></div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Main Course in the Center */}
+      <div
+        style={{
+          fontWeight: "bold",
+          textAlign: "center",
+          padding: "5px 10px",
+          fontSize: "14px",
+          backgroundColor: "#e5e7eb",
+          color: "#111827",
+          border: "1px solid #9ca3af",
+          borderRadius: "4px",
+          boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.1)",
+          margin: "0 20px",
+        }}
+      >
+        {root.courseID}
+      </div>
+
+      {/* Postrequisites on the Right */}
+      {root.postreqs && root.postreqs.length > 0 && (
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", marginLeft: "20px" }}>
+          {root.postreqs.map((postreq) => (
+            <div key={postreq.courseID} style={{ display: "flex", alignItems: "center", marginBottom: "10px" }}>
+              <div
+                style={{
+                  width: "20px",
+                  height: "1px",
+                  backgroundColor: "#d1d5db",
+                  marginRight: "5px",
+                }}
+              ></div>
+              <Link href={`/course/${postreq.courseID}`} passHref>
+                <div
+                  style={{
+                    fontWeight: "normal",
+                    textAlign: "center",
+                    padding: "5px 10px",
+                    fontSize: "14px",
+                    backgroundColor: "#f9fafb", 
+                    color: "#111827",
+                    border: "1px solid #d1d5db",
+                    borderRadius: "4px",
+                    boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
+                    cursor: "pointer",
+                  }}
+                >
+                  {postreq.courseID}
+                </div>
+              </Link>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ReqTreeDetail;

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -5,7 +5,6 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
 } from "@heroicons/react/20/solid";
-import { FlushedButton } from "./Buttons";
 import { TreeNode } from "~/app/types";
 
 interface ReqTreeProps {
@@ -25,7 +24,10 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
   };
 
   return (
-    <div className="flex items-center justify-center overflow-x-scroll">
+    <div className="flex overflow-auto">
+      {/* Padding */}
+      <div className="flex-grow"></div>
+
       {/* Prereqs on the left */}
       {root.prereqs && root.prereqs.length > 0 && (
         <div className="flex flex-col items-end justify-center">
@@ -41,22 +43,21 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               )}
 
               {/* Expansion button */}
-              <button className="right-3 top-3 z-40 md:top-4 md:right-2">
-                <FlushedButton
-                  onClick={() => togglePreReqs(prereq.courseID)}
-                >
-                  {expandedPreReqID === prereq.courseID ?
-                    <div className="hidden items-center md:flex">
-                      <div className="mr-1">Hide</div>
-                      <ChevronRightIcon className="h-5 w-5" />
-                    </div>
-                    :
-                    <div className="hidden items-center md:flex">
-                      <ChevronLeftIcon className="h-5 w-5" />
-                    </div>
-                  }
-                </FlushedButton>
-              </button>
+              <div
+                className="text-gray-700 cursor-pointer rounded py-1 px-2 text-sm hover:bg-gray-50"
+                onClick={() => togglePreReqs(prereq.courseID)}
+              >
+                {expandedPreReqID === prereq.courseID ? (
+                  <div className="flex items-center">
+                    <div className="mr-1 hidden md:block">Hide</div>
+                    <ChevronRightIcon className="h-5 w-5" />
+                  </div>
+                ) : (
+                  <div className="flex items-center">
+                    <ChevronLeftIcon className="h-5 w-5" />
+                  </div>
+                )}
+              </div>
 
               {/* Line right to expansion button */}
               <div className="w-3 h-0.5 bg-gray-400"></div>
@@ -64,7 +65,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               {/* Course ID button */}
               <button
                 onClick={() => (window.location.href = `/course/${prereq.courseID}`)}
-                className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
+                className="font-normal text-center px-2 py-1 text-base bg-gray-50 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
               >
                 {prereq.courseID}
               </button>
@@ -109,7 +110,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
 
         {/* Main node */}
         <div
-          className="font-bold text-center px-2 py-1 text-base bg-[#e5e7eb] text-[#111827] border border-[#9ca3af] rounded shadow-md min-w-[80px] mt-[10px] mb-[10px]"
+          className="font-bold text-center px-2 py-1 text-base bg-gray-200 text-gray-900 border border-gray-400 rounded shadow-md min-w-[80px] mt-[10px] mb-[10px]"
         >
           {root.courseID}
         </div>
@@ -152,7 +153,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               {/* Course ID button */}
               <button
                 onClick={() => (window.location.href = `/course/${postreq.courseID}`)}
-                className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
+                className="font-normal text-center px-2 py-1 text-base bg-gray-50 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
               >
                 {postreq.courseID}
               </button>
@@ -161,22 +162,21 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               <div className="w-3 h-0.5 bg-gray-400"></div>
 
               {/* Expansion button */}
-              <button className="right-3 top-3 z-40 md:top-4 md:right-2">
-                <FlushedButton
-                  onClick={() => togglePostReqs(postreq.courseID)}
-                >
-                  {expandedPostReqID === postreq.courseID ?
-                    <div className="hidden items-center md:flex">
-                      <div className="mr-1">Hide</div>
-                      <ChevronLeftIcon className="h-5 w-5" />
-                    </div>
-                    :
-                    <div className="hidden items-center md:flex">
-                      <ChevronRightIcon className="h-5 w-5" />
-                    </div>
-                  }
-                </FlushedButton>
-              </button>
+              <div
+                className="text-gray-700 cursor-pointer rounded py-1 px-2 text-sm hover:bg-gray-50"
+                onClick={() => togglePostReqs(postreq.courseID)}
+              >
+                {expandedPostReqID === postreq.courseID ? (
+                  <div className="flex items-center">
+                    <div className="mr-1 hidden md:block">Hide</div>
+                    <ChevronLeftIcon className="h-5 w-5" />
+                  </div>
+                ) : (
+                  <div className="flex items-center">
+                    <ChevronRightIcon className="h-5 w-5" />
+                  </div>
+                )}
+              </div>
 
               {/* Next level of postreqs */}
               {expandedPostReqID === postreq.courseID && (
@@ -190,6 +190,9 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
           ))}
         </div>
       )}
+
+      {/* Padding */}
+      <div className="flex-grow"></div>
     </div>
   );
 };

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from "react";
 import Link from "next/link";
 import PostReqCourses from "./PostReqCourses"; // Import PostReqCourses component
+import PreReqCourses from "./PreReqCourses";   // Import PreReqCourses component
 
 interface TreeNode {
   courseID: string;
+  coreqs?: Array<{ courseID: string }>;
   prereqs?: TreeNode[];
   postreqs?: TreeNode[];
 }
@@ -13,11 +15,15 @@ interface ReqTreeProps {
 }
 
 const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
-  const [expandedCourseID, setExpandedCourseID] = useState<string | null>(null);
+  const [expandedPostReqID, setExpandedPostReqID] = useState<string | null>(null);
+  const [expandedPreReqID, setExpandedPreReqID] = useState<string | null>(null);
 
   const togglePostReqs = (courseID: string) => {
-    // Toggle expanded state for the course
-    setExpandedCourseID((prev) => (prev === courseID ? null : courseID));
+    setExpandedPostReqID((prev) => (prev === courseID ? null : courseID));
+  };
+
+  const togglePreReqs = (courseID: string) => {
+    setExpandedPreReqID((prev) => (prev === courseID ? null : courseID));
   };
 
   return (
@@ -26,7 +32,31 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
       {root.prereqs && root.prereqs.length > 0 && (
         <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", marginRight: "20px" }}>
           {root.prereqs.map((prereq) => (
-            <div key={prereq.courseID} style={{ display: "flex", alignItems: "center", marginBottom: "10px" }}>
+            <div
+              key={prereq.courseID}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                marginBottom: "10px",
+              }}
+            >
+              <button
+                aria-label={`Toggle prerequisites for ${prereq.courseID}`}
+                style={{
+                  marginRight: "5px",
+                  padding: "5px 10px",
+                  backgroundColor: "#007BFF",
+                  color: "#FFFFFF",
+                  border: "none",
+                  borderRadius: "4px",
+                  cursor: "pointer",
+                  fontSize: "12px",
+                }}
+                onClick={() => togglePreReqs(prereq.courseID)}
+              >
+                {expandedPreReqID === prereq.courseID ? "Hide" : "View More"}
+              </button>
+
               <Link href={`/course/${prereq.courseID}`} passHref>
                 <div
                   style={{
@@ -40,42 +70,71 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                     borderRadius: "4px",
                     boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
                     cursor: "pointer",
-                    minWidth: "80px", // Consistent width
+                    minWidth: "80px",
                   }}
                 >
                   {prereq.courseID}
                 </div>
               </Link>
-              <div
-                style={{
-                  width: "20px",
-                  height: "1px",
-                  backgroundColor: "#d1d5db",
-                  marginLeft: "5px",
-                }}
-              ></div>
+
+              {expandedPreReqID === prereq.courseID && (
+                <div style={{ marginTop: "10px", marginLeft: "20px" }}>
+                  <PreReqCourses courseID={prereq.courseID} />
+                </div>
+              )}
             </div>
           ))}
         </div>
       )}
 
-      {/* Main Course in the Center */}
-      <div
-        style={{
-          fontWeight: "bold",
-          textAlign: "center",
-          padding: "5px 10px",
-          fontSize: "14px",
-          backgroundColor: "#e5e7eb",
-          color: "#111827",
-          border: "1px solid #9ca3af",
-          borderRadius: "4px",
-          boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.1)",
-          margin: "0 20px",
-          minWidth: "80px", // Consistent width
-        }}
-      >
-        {root.courseID}
+      {/* Main Course in the Center with Corequisites Below */}
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", margin: "0 20px" }}>
+        <div
+          style={{
+            fontWeight: "bold",
+            textAlign: "center",
+            padding: "5px 10px",
+            fontSize: "14px",
+            backgroundColor: "#e5e7eb",
+            color: "#111827",
+            border: "1px solid #9ca3af",
+            borderRadius: "4px",
+            boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.1)",
+            minWidth: "80px",
+          }}
+        >
+          {root.courseID}
+        </div>
+
+        {/* Corequisites directly below */}
+        {root.coreqs && root.coreqs.length > 0 && (
+          <div style={{ marginTop: "10px", textAlign: "center" }}>
+            <div style={{ fontWeight: "bold" }}>Corequisites:</div>
+            <div style={{ display: "flex", flexWrap: "wrap", justifyContent: "center", gap: "10px", marginTop: "5px" }}>
+              {root.coreqs.map((coreq) => (
+                <Link href={`/course/${coreq.courseID}`} passHref key={coreq.courseID}>
+                  <div
+                    style={{
+                      fontWeight: "normal",
+                      textAlign: "center",
+                      padding: "5px 10px",
+                      fontSize: "14px",
+                      backgroundColor: "#f9fafb",
+                      color: "#111827",
+                      border: "1px solid #d1d5db",
+                      borderRadius: "4px",
+                      boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
+                      cursor: "pointer",
+                      minWidth: "80px",
+                    }}
+                  >
+                    {coreq.courseID}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Postrequisites on the Right */}
@@ -88,17 +147,8 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                 display: "flex",
                 alignItems: "center",
                 marginBottom: "10px",
-                justifyContent: "space-between", // Space between course ID and button
               }}
             >
-              <div
-                style={{
-                  width: "20px",
-                  height: "1px",
-                  backgroundColor: "#d1d5db",
-                  marginRight: "5px",
-                }}
-              ></div>
               <Link href={`/course/${postreq.courseID}`} passHref>
                 <div
                   style={{
@@ -112,8 +162,8 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                     borderRadius: "4px",
                     boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
                     cursor: "pointer",
-                    minWidth: "80px", // Consistent width
-                    marginRight: "10px", // Space between course ID and button
+                    minWidth: "80px",
+                    marginRight: "10px",
                   }}
                 >
                   {postreq.courseID}
@@ -124,7 +174,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                 style={{
                   marginLeft: "5px",
                   padding: "5px 10px",
-                  backgroundColor: "#007BFF", // Button color
+                  backgroundColor: "#007BFF",
                   color: "#FFFFFF",
                   border: "none",
                   borderRadius: "4px",
@@ -133,10 +183,9 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                 }}
                 onClick={() => togglePostReqs(postreq.courseID)}
               >
-                {expandedCourseID === postreq.courseID ? "Hide" : "View More"}
+                {expandedPostReqID === postreq.courseID ? "Hide" : "View More"}
               </button>
-              {/* Render PostReqCourses dynamically */}
-              {expandedCourseID === postreq.courseID && (
+              {expandedPostReqID === postreq.courseID && (
                 <div style={{ marginTop: "10px", marginLeft: "20px" }}>
                   <PostReqCourses courseID={postreq.courseID} />
                 </div>

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -27,20 +27,12 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
   };
 
   return (
-    <div style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
-
+    <div className="flex items-center justify-center">
       {/* Prerequisites on the Left */}
       {root.prereqs && root.prereqs.length > 0 && (
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end" }}>
+        <div className="flex flex-col items-end">
           {root.prereqs.map((prereq) => (
-            <div
-              key={prereq.courseID}
-              style={{
-                display: "flex",
-                alignItems: "center",
-              }}
-            >
-
+            <div key={prereq.courseID} className="flex items-center">
               {expandedPreReqID === prereq.courseID && (
                 <div>
                   <PreReqCourses courseID={prereq.courseID} />
@@ -48,105 +40,46 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               )}
 
               {/* Line left to expansion button */}
-              <div
-                style={{
-                  width: "10px",
-                  height: "1px",
-                  backgroundColor: "#d1d5db",
-                }}
-              ></div>
+              <div className="w-[10px] h-[1px] bg-gray-300"></div>
 
               <button
-                aria-label={`Toggle prerequisites for ${prereq.courseID}`}
-                style={{
-                  padding: "5px 10px",
-                  backgroundColor: "#007BFF",
-                  color: "#FFFFFF",
-                  border: "none",
-                  borderRadius: "4px",
-                  cursor: "pointer",
-                  fontSize: "12px",
-                }}
-                onClick={() => togglePreReqs(prereq.courseID)}
+              aria-label={`Toggle prerequisites for ${prereq.courseID}`}
+              className="px-2 py-1 bg-[#007fff] text-white border-none rounded cursor-pointer text-sm"
+              onClick={() => togglePreReqs(prereq.courseID)}
               >
                 {expandedPreReqID === prereq.courseID ? ">" : "<"}
               </button>
 
               {/* Line connector left to node */}
-              <div
-                style={{
-                  width: "10px",
-                  height: "1px",
-                  backgroundColor: "#d1d5db",
-                }}
-              ></div>
+              <div className="w-[10px] h-[1px] bg-[#d1d5db]]"></div>
 
               <Link href={`/course/${prereq.courseID}`} passHref>
                 <div
-                  style={{
-                    fontWeight: "normal",
-                    textAlign: "center",
-                    padding: "5px 10px",
-                    fontSize: "14px",
-                    backgroundColor: "#f9fafb",
-                    color: "#111827",
-                    border: "1px solid #d1d5db",
-                    borderRadius: "4px",
-                    boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
-                    cursor: "pointer",
-                    minWidth: "80px",
-                    marginTop: "2px",
-                    marginBottom: "2px",
-                  }}
+                className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer min-w-[80px] mt-[2px] mb-[2px]"
                 >
                   {prereq.courseID}
                 </div>
+
               </Link>
 
               {/* Line connector right to node */}
               {root.prereqs && root.prereqs.length > 1 && (
-                <div
-                  style={{
-                    width: "20px",
-                    height: "1px",
-                    backgroundColor: "#d1d5db",
-                  }}
-                ></div>
+                <div className="w-[20px] h-[1px] bg-[#d1d5db]"></div>
               )}
 
               {/* Half vertical line for the first prereq in the list */}
               {root.prereqs && root.prereqs.length > 1 && root.prereqs.indexOf(prereq) === 0 && (
-                <div
-                  style={{
-                    width: "1px",
-                    height: "20px",
-                    backgroundColor: "#d1d5db",
-                    marginTop: "20px",
-                  }}
-                ></div>
+                <div className="w-[1px] h-[20px] bg-[#d1d5db] mt-[20px]"></div>
               )}
 
               {/* Normal vertical Line connector */}
               {root.prereqs && root.prereqs.length > 1 && root.prereqs.indexOf(prereq) !== 0 && root.prereqs.indexOf(prereq) !== root.prereqs.length - 1 && (
-                <div
-                  style={{
-                    width: "1px",
-                    backgroundColor: "#d1d5db",
-                    alignSelf: "stretch",
-                  }}
-                ></div>
+                <div className="w-[1px] bg-[#d1d5db] self-stretch"></div>
               )}
 
               {/* Half vertical line for the last prereq in the list */}
               {root.prereqs && root.prereqs.length > 1 && root.prereqs.indexOf(prereq) === root.prereqs.length - 1 && (
-                <div
-                  style={{
-                    width: "1px",
-                    height: "20px",
-                    backgroundColor: "#d1d5db",
-                    marginBottom: "20px",
-                  }}
-                ></div>
+                <div className="w-[1px] h-[20px] bg-[#d1d5db] mb-[20px]"></div>
               )}
 
             </div>
@@ -155,28 +88,14 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
       )}
 
       {/* Main Course in the Center with Corequisites Above and Below */}
-      <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+      <div className="flex flex-col items-center">
         {/* Corequisites Above */}
         {root.coreqs && root.coreqs.length > 0 && (
-          <div style={{ textAlign: "center" }}>
+          <div className="text-center">
             {root.coreqs.slice(0, Math.ceil(root.coreqs.length / 2)).map((coreq) => (
               <Link href={`/course/${coreq.courseID}`} passHref key={coreq.courseID}>
                 <div
-                  style={{
-                    fontWeight: "normal",
-                    textAlign: "center",
-                    padding: "5px 10px",
-                    fontSize: "14px",
-                    backgroundColor: "#f9fafb",
-                    color: "#111827",
-                    border: "1px solid #d1d5db",
-                    borderRadius: "4px",
-                    boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
-                    cursor: "pointer",
-                    minWidth: "80px",
-                    marginTop: "2px",
-                    marginBottom: "2px",
-                  }}
+                className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer min-w-[80px] mt-[2px] mb-[2px]"
                 >
                   {coreq.courseID}
                 </div>
@@ -186,74 +105,32 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
         )}
 
         {/* Main Course */}
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-          }}
-        >
+        <div className="flex items-center">
           {/* Line connector */}
           {root.prereqs && root.prereqs.length > 0 && (
-            <div
-              style={{
-                width: "20px",
-                height: "1px",
-                backgroundColor: "#d1d5db",
-              }}
-            ></div>)}
+            <div className="w-[20px] h-[1px] bg-[#d1d5db]"></div>
+          )}
 
           {/* root node */}
           <div
-            style={{
-              fontWeight: "bold",
-              textAlign: "center",
-              padding: "5px 10px",
-              fontSize: "14px",
-              backgroundColor: "#e5e7eb",
-              color: "#111827",
-              border: "1px solid #9ca3af",
-              borderRadius: "4px",
-              boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.1)",
-              minWidth: "80px",
-              marginTop: "10px",
-              marginBottom: "10px",
-            }}
+          className="font-bold text-center px-2 py-1 text-base bg-[#e5e7eb] text-[#111827] border border-[#9ca3af] rounded shadow-md min-w-[80px] mt-[10px] mb-[10px]"
           >
             {root.courseID}
           </div>
 
           {/* Line connector */}
           {root.postreqs && root.postreqs.length > 0 && (
-            <div
-              style={{
-                width: "20px",
-                height: "1px",
-                backgroundColor: "#d1d5db",
-              }}
-            ></div>)}
+            <div className="w-[20px] h-[1px] bg-[#d1d5db]"></div>
+          )}
         </div>
 
         {/* Corequisites Below */}
         {root.coreqs && root.coreqs.length > 0 && (
-          <div style={{ textAlign: "center" }}>
+          <div className="text-center">
             {root.coreqs.slice(Math.ceil(root.coreqs.length / 2)).map((coreq) => (
               <Link href={`/course/${coreq.courseID}`} passHref key={coreq.courseID}>
                 <div
-                  style={{
-                    fontWeight: "normal",
-                    textAlign: "center",
-                    padding: "5px 10px",
-                    fontSize: "14px",
-                    backgroundColor: "#f9fafb",
-                    color: "#111827",
-                    border: "1px solid #d1d5db",
-                    borderRadius: "4px",
-                    boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
-                    cursor: "pointer",
-                    minWidth: "80px",
-                    marginTop: "2px",
-                    marginBottom: "2px",
-                  }}
+                className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer min-w-[80px] mt-[2px] mb-[2px]"
                 >
                   {coreq.courseID}
                 </div>
@@ -265,116 +142,49 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
 
       {/* Postrequisites on the Right */}
       {root.postreqs && root.postreqs.length > 0 && (
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+        <div className="flex flex-col items-start">
           {root.postreqs.map((postreq) => (
-            <div
-              key={postreq.courseID}
-              style={{
-                display: "flex",
-                alignItems: "center",
-              }}
-            >
+            <div key={postreq.courseID} className="flex items-center">
               {/* Half vertical line for the first postreq */}
               {root.postreqs && root.postreqs.length > 1 && root.postreqs.indexOf(postreq) === 0 && (
-                <div
-                  style={{
-                    width: "1px",
-                    height: "20px",
-                    backgroundColor: "#d1d5db",
-                    marginTop: "20px",
-                  }}
-                ></div>
+                <div className="w-[1px] h-[20px] bg-[#d1d5db] mt-[20px]"></div>
               )}
 
               {/* Normal vertical Line connector */}
               {root.postreqs && root.postreqs.length > 1 && root.postreqs.indexOf(postreq) !== 0 && root.postreqs.indexOf(postreq) !== root.postreqs.length - 1 && (
-                <div
-                  style={{
-                    width: "1px",
-                    backgroundColor: "#d1d5db",
-                    alignSelf: "stretch",
-                  }}
-                ></div>
+                <div className="w-[1px] bg-[#d1d5db] self-stretch"></div>
               )}
 
               {/* Half vertical line for the last postreq */}
               {root.postreqs && root.postreqs.length > 1 && root.postreqs.indexOf(postreq) === root.postreqs.length - 1 && (
-                <div
-                  style={{
-                    width: "1px",
-                    height: "20px",
-                    backgroundColor: "#d1d5db",
-                    marginBottom: "20px", // Move the line to the to half
-                  }}
-                ></div>
+                <div className="w-[1px] h-[20px] bg-[#d1d5db] mb-[20px]"></div>
               )}
 
               {/* Line connector right to postreqs */}
-              {root.postreqs && root.postreqs.length > 1 && (
-                <div
-                  style={{
-                    width: "20px",
-                    height: "1px",
-                    backgroundColor: "#d1d5db",
-                  }}
-                ></div>
-              )}
+              <div className="w-[20px] h-[1px] bg-[#d1d5db]"></div>
 
               <Link href={`/course/${postreq.courseID}`} passHref>
-                <div
-                  style={{
-                    fontWeight: "normal",
-                    textAlign: "center",
-                    padding: "5px 10px",
-                    fontSize: "14px",
-                    backgroundColor: "#f9fafb",
-                    color: "#111827",
-                    border: "1px solid #d1d5db",
-                    borderRadius: "4px",
-                    boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
-                    cursor: "pointer",
-                    minWidth: "80px",
-                    marginTop: "2px",
-                    marginBottom: "2px",
-                  }}
-                >
-                  {postreq.courseID}
-                </div>
+              <div
+              className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer min-w-[80px] mt-[2px] mb-[2px]"
+              >
+                {postreq.courseID}
+              </div>
               </Link>
 
               {/* Line connector right to node */}
-              <div
-                style={{
-                  width: "10px",
-                  height: "1px",
-                  backgroundColor: "#d1d5db",
-                }}
-              ></div>
+              <div className="w-[10px] h-[1px] bg-[#d1d5db]"></div>
 
               <button
-                aria-label={`Toggle post-requisites for ${postreq.courseID}`}
-                style={{
-                  padding: "5px 10px",
-                  backgroundColor: "#007BFF",
-                  color: "#FFFFFF",
-                  border: "none",
-                  borderRadius: "4px",
-                  cursor: "pointer",
-                  fontSize: "12px",
-                }}
-                onClick={() => togglePostReqs(postreq.courseID)}
+              aria-label={`Toggle post-requisites for ${postreq.courseID}`}
+              className= "px-2 py-1 bg-[#007fff] text-white border-none rounded cursor-pointer text-sm"
+              onClick={() => togglePostReqs(postreq.courseID)}
               >
                 {expandedPostReqID === postreq.courseID ? "<" : ">"}
               </button>
 
+
               {/* Line right to expansion button */}
-              <div
-                style={{
-                  width: "10px",
-                  height: "1px",
-                  backgroundColor: "#d1d5db",
-                }}
-              ></div>
+              <div className="w-[10px] h-[1px] bg-[#d1d5db]"></div>
 
               {expandedPostReqID === postreq.courseID && (
                 <div>

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from "react";
 import Link from "next/link";
-import PostReqCourses from "./PostReqCourses"; // Import PostReqCourses component
-import PreReqCourses from "./PreReqCourses";   // Import PreReqCourses component
+import PostReqCourses from "./PostReqCourses";
+import PreReqCourses from "./PreReqCourses";
 
 interface TreeNode {
   courseID: string;
   coreqs?: Array<{ courseID: string }>;
   prereqs?: TreeNode[];
+  prereqRelations?: TreeNode[][];
   postreqs?: TreeNode[];
 }
 

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -87,8 +87,37 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
         </div>
       )}
 
-      {/* Main Course in the Center with Corequisites Below */}
+      {/* Main Course in the Center with Corequisites Above and Below */}
       <div style={{ display: "flex", flexDirection: "column", alignItems: "center", margin: "0 20px" }}>
+        {/* Corequisites Above */}
+        {root.coreqs && root.coreqs.length > 0 && (
+          <div style={{ marginBottom: "10px", textAlign: "center" }}>
+            {root.coreqs.slice(0, Math.ceil(root.coreqs.length / 2)).map((coreq) => (
+              <Link href={`/course/${coreq.courseID}`} passHref key={coreq.courseID}>
+                <div
+                  style={{
+                    fontWeight: "normal",
+                    textAlign: "center",
+                    padding: "5px 10px",
+                    fontSize: "14px",
+                    backgroundColor: "#f9fafb",
+                    color: "#111827",
+                    border: "1px solid #d1d5db",
+                    borderRadius: "4px",
+                    boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
+                    cursor: "pointer",
+                    minWidth: "80px",
+                    marginBottom: "5px",
+                  }}
+                >
+                  {coreq.courseID}
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+
+        {/* Main Course */}
         <div
           style={{
             fontWeight: "bold",
@@ -106,33 +135,31 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
           {root.courseID}
         </div>
 
-        {/* Corequisites directly below */}
+        {/* Corequisites Below */}
         {root.coreqs && root.coreqs.length > 0 && (
           <div style={{ marginTop: "10px", textAlign: "center" }}>
-            <div style={{ fontWeight: "bold" }}>Corequisites:</div>
-            <div style={{ display: "flex", flexWrap: "wrap", justifyContent: "center", gap: "10px", marginTop: "5px" }}>
-              {root.coreqs.map((coreq) => (
-                <Link href={`/course/${coreq.courseID}`} passHref key={coreq.courseID}>
-                  <div
-                    style={{
-                      fontWeight: "normal",
-                      textAlign: "center",
-                      padding: "5px 10px",
-                      fontSize: "14px",
-                      backgroundColor: "#f9fafb",
-                      color: "#111827",
-                      border: "1px solid #d1d5db",
-                      borderRadius: "4px",
-                      boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
-                      cursor: "pointer",
-                      minWidth: "80px",
-                    }}
-                  >
-                    {coreq.courseID}
-                  </div>
-                </Link>
-              ))}
-            </div>
+            {root.coreqs.slice(Math.ceil(root.coreqs.length / 2)).map((coreq) => (
+              <Link href={`/course/${coreq.courseID}`} passHref key={coreq.courseID}>
+                <div
+                  style={{
+                    fontWeight: "normal",
+                    textAlign: "center",
+                    padding: "5px 10px",
+                    fontSize: "14px",
+                    backgroundColor: "#f9fafb",
+                    color: "#111827",
+                    border: "1px solid #d1d5db",
+                    borderRadius: "4px",
+                    boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
+                    cursor: "pointer",
+                    minWidth: "80px",
+                    marginTop: "5px",
+                  }}
+                >
+                  {coreq.courseID}
+                </div>
+              </Link>
+            ))}
           </div>
         )}
       </div>

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -6,6 +6,7 @@ import {
   ChevronRightIcon,
 } from "@heroicons/react/20/solid";
 import { TreeNode } from "~/app/types";
+import { GetTooltip } from "./GetTooltip";
 
 interface ReqTreeProps {
   root: TreeNode;
@@ -148,7 +149,9 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               )}
 
               {/* Line left to node */}
-              <div className="w-3 h-0.5 bg-gray-400"></div>
+              {root.postreqs && root.postreqs.length > 1 && (
+                <div className="w-3 h-0.5 bg-gray-400"></div>
+              )}
 
               {/* Course ID button */}
               <button

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -28,28 +28,37 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
 
   return (
     <div style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
+
       {/* Prerequisites on the Left */}
       {root.prereqs && root.prereqs.length > 0 && (
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", marginRight: "20px" }}>
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end" }}>
           {root.prereqs.map((prereq) => (
             <div
               key={prereq.courseID}
               style={{
                 display: "flex",
                 alignItems: "center",
-                marginBottom: "10px",
               }}
             >
+
               {expandedPreReqID === prereq.courseID && (
-                <div style={{ marginRight: "20px" }}>
+                <div>
                   <PreReqCourses courseID={prereq.courseID} />
                 </div>
               )}
 
+              {/* Line left to expansion button */}
+              <div
+                style={{
+                  width: "10px",
+                  height: "1px",
+                  backgroundColor: "#d1d5db",
+                }}
+              ></div>
+
               <button
                 aria-label={`Toggle prerequisites for ${prereq.courseID}`}
                 style={{
-                  marginRight: "5px",
                   padding: "5px 10px",
                   backgroundColor: "#007BFF",
                   color: "#FFFFFF",
@@ -60,10 +69,17 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                 }}
                 onClick={() => togglePreReqs(prereq.courseID)}
               >
-                {expandedPreReqID === prereq.courseID ? "Hide" : "View More"}
+                {expandedPreReqID === prereq.courseID ? ">" : "<"}
               </button>
 
-              {/* Line connector */}
+              {/* Line connector left to node */}
+              <div
+                style={{
+                  width: "10px",
+                  height: "1px",
+                  backgroundColor: "#d1d5db",
+                }}
+              ></div>
 
               <Link href={`/course/${prereq.courseID}`} passHref>
                 <div
@@ -79,21 +95,70 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                     boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
                     cursor: "pointer",
                     minWidth: "80px",
+                    marginTop: "2px",
+                    marginBottom: "2px",
                   }}
                 >
                   {prereq.courseID}
                 </div>
               </Link>
+
+              {/* Line connector right to node */}
+              {root.prereqs && root.prereqs.length > 1 && (
+                <div
+                  style={{
+                    width: "20px",
+                    height: "1px",
+                    backgroundColor: "#d1d5db",
+                  }}
+                ></div>
+              )}
+
+              {/* Half vertical line for the first prereq in the list */}
+              {root.prereqs && root.prereqs.length > 1 && root.prereqs.indexOf(prereq) === 0 && (
+                <div
+                  style={{
+                    width: "1px",
+                    height: "20px",
+                    backgroundColor: "#d1d5db",
+                    marginTop: "20px",
+                  }}
+                ></div>
+              )}
+
+              {/* Normal vertical Line connector */}
+              {root.prereqs && root.prereqs.length > 1 && root.prereqs.indexOf(prereq) !== 0 && root.prereqs.indexOf(prereq) !== root.prereqs.length - 1 && (
+                <div
+                  style={{
+                    width: "1px",
+                    backgroundColor: "#d1d5db",
+                    alignSelf: "stretch",
+                  }}
+                ></div>
+              )}
+
+              {/* Half vertical line for the last prereq in the list */}
+              {root.prereqs && root.prereqs.length > 1 && root.prereqs.indexOf(prereq) === root.prereqs.length - 1 && (
+                <div
+                  style={{
+                    width: "1px",
+                    height: "20px",
+                    backgroundColor: "#d1d5db",
+                    marginBottom: "20px",
+                  }}
+                ></div>
+              )}
+
             </div>
           ))}
         </div>
       )}
 
       {/* Main Course in the Center with Corequisites Above and Below */}
-      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", margin: "0 20px" }}>
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
         {/* Corequisites Above */}
         {root.coreqs && root.coreqs.length > 0 && (
-          <div style={{ marginBottom: "10px", textAlign: "center" }}>
+          <div style={{ textAlign: "center" }}>
             {root.coreqs.slice(0, Math.ceil(root.coreqs.length / 2)).map((coreq) => (
               <Link href={`/course/${coreq.courseID}`} passHref key={coreq.courseID}>
                 <div
@@ -109,7 +174,8 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                     boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
                     cursor: "pointer",
                     minWidth: "80px",
-                    marginBottom: "5px",
+                    marginTop: "2px",
+                    marginBottom: "2px",
                   }}
                 >
                   {coreq.courseID}
@@ -122,24 +188,54 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
         {/* Main Course */}
         <div
           style={{
-            fontWeight: "bold",
-            textAlign: "center",
-            padding: "5px 10px",
-            fontSize: "14px",
-            backgroundColor: "#e5e7eb",
-            color: "#111827",
-            border: "1px solid #9ca3af",
-            borderRadius: "4px",
-            boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.1)",
-            minWidth: "80px",
+            display: "flex",
+            alignItems: "center",
           }}
         >
-          {root.courseID}
+          {/* Line connector */}
+          {root.prereqs && root.prereqs.length > 0 && (
+            <div
+              style={{
+                width: "20px",
+                height: "1px",
+                backgroundColor: "#d1d5db",
+              }}
+            ></div>)}
+
+          {/* root node */}
+          <div
+            style={{
+              fontWeight: "bold",
+              textAlign: "center",
+              padding: "5px 10px",
+              fontSize: "14px",
+              backgroundColor: "#e5e7eb",
+              color: "#111827",
+              border: "1px solid #9ca3af",
+              borderRadius: "4px",
+              boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.1)",
+              minWidth: "80px",
+              marginTop: "10px",
+              marginBottom: "10px",
+            }}
+          >
+            {root.courseID}
+          </div>
+
+          {/* Line connector */}
+          {root.postreqs && root.postreqs.length > 0 && (
+            <div
+              style={{
+                width: "20px",
+                height: "1px",
+                backgroundColor: "#d1d5db",
+              }}
+            ></div>)}
         </div>
 
         {/* Corequisites Below */}
         {root.coreqs && root.coreqs.length > 0 && (
-          <div style={{ marginTop: "10px", textAlign: "center" }}>
+          <div style={{ textAlign: "center" }}>
             {root.coreqs.slice(Math.ceil(root.coreqs.length / 2)).map((coreq) => (
               <Link href={`/course/${coreq.courseID}`} passHref key={coreq.courseID}>
                 <div
@@ -155,7 +251,8 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                     boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
                     cursor: "pointer",
                     minWidth: "80px",
-                    marginTop: "5px",
+                    marginTop: "2px",
+                    marginBottom: "2px",
                   }}
                 >
                   {coreq.courseID}
@@ -168,16 +265,59 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
 
       {/* Postrequisites on the Right */}
       {root.postreqs && root.postreqs.length > 0 && (
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", marginLeft: "20px" }}>
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
           {root.postreqs.map((postreq) => (
             <div
               key={postreq.courseID}
               style={{
                 display: "flex",
                 alignItems: "center",
-                marginBottom: "10px",
               }}
             >
+              {/* Half vertical line for the first postreq */}
+              {root.postreqs && root.postreqs.length > 1 && root.postreqs.indexOf(postreq) === 0 && (
+                <div
+                  style={{
+                    width: "1px",
+                    height: "20px",
+                    backgroundColor: "#d1d5db",
+                    marginTop: "20px",
+                  }}
+                ></div>
+              )}
+
+              {/* Normal vertical Line connector */}
+              {root.postreqs && root.postreqs.length > 1 && root.postreqs.indexOf(postreq) !== 0 && root.postreqs.indexOf(postreq) !== root.postreqs.length - 1 && (
+                <div
+                  style={{
+                    width: "1px",
+                    backgroundColor: "#d1d5db",
+                    alignSelf: "stretch",
+                  }}
+                ></div>
+              )}
+
+              {/* Half vertical line for the last postreq */}
+              {root.postreqs && root.postreqs.length > 1 && root.postreqs.indexOf(postreq) === root.postreqs.length - 1 && (
+                <div
+                  style={{
+                    width: "1px",
+                    height: "20px",
+                    backgroundColor: "#d1d5db",
+                    marginBottom: "20px", // Move the line to the to half
+                  }}
+                ></div>
+              )}
+
+              {/* Line connector right to postreqs */}
+              <div
+                style={{
+                  width: "20px",
+                  height: "1px",
+                  backgroundColor: "#d1d5db",
+                }}
+              ></div>
+
               <Link href={`/course/${postreq.courseID}`} passHref>
                 <div
                   style={{
@@ -192,16 +332,26 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                     boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
                     cursor: "pointer",
                     minWidth: "80px",
-                    marginRight: "10px",
+                    marginTop: "2px",
+                    marginBottom: "2px",
                   }}
                 >
                   {postreq.courseID}
                 </div>
               </Link>
+
+              {/* Line connector right to node */}
+              <div
+                style={{
+                  width: "10px",
+                  height: "1px",
+                  backgroundColor: "#d1d5db",
+                }}
+              ></div>
+
               <button
                 aria-label={`Toggle post-requisites for ${postreq.courseID}`}
                 style={{
-                  marginLeft: "5px",
                   padding: "5px 10px",
                   backgroundColor: "#007BFF",
                   color: "#FFFFFF",
@@ -212,13 +362,24 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                 }}
                 onClick={() => togglePostReqs(postreq.courseID)}
               >
-                {expandedPostReqID === postreq.courseID ? "Hide" : "View More"}
+                {expandedPostReqID === postreq.courseID ? "<" : ">"}
               </button>
+
+              {/* Line right to expansion button */}
+              <div
+                style={{
+                  width: "10px",
+                  height: "1px",
+                  backgroundColor: "#d1d5db",
+                }}
+              ></div>
+
               {expandedPostReqID === postreq.courseID && (
-                <div style={{ marginTop: "10px", marginLeft: "20px" }}>
+                <div>
                   <PostReqCourses courseID={postreq.courseID} />
                 </div>
               )}
+
             </div>
           ))}
         </div>

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -2,6 +2,11 @@ import React, { useState } from "react";
 import Link from "next/link";
 import PostReqCourses from "./PostReqCourses";
 import PreReqCourses from "./PreReqCourses";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from "@heroicons/react/20/solid";
+import { FlushedButton } from "./Buttons";
 
 interface TreeNode {
   courseID: string;
@@ -28,59 +33,74 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
   };
 
   return (
-    <div className="flex items-center justify-center">
-      {/* Prerequisites on the Left */}
+    <div className="flex items-center justify-center overflow-x-scroll">
+      {/* Prereqs on the left */}
       {root.prereqs && root.prereqs.length > 0 && (
-        <div className="flex flex-col items-end">
+        <div className="flex flex-col items-end justify-center">
           {root.prereqs.map((prereq) => (
-            <div key={prereq.courseID} className="flex items-center">
+            <div key={prereq.courseID} className="flex items-center justify-center">
+
+              {/* Next level of prereqs */}
               {expandedPreReqID === prereq.courseID && (
-                <div>
+                <div className="flex items-center justify-center">
                   <PreReqCourses courseID={prereq.courseID} />
+                  <div className="w-3 h-0.5 bg-gray-400"></div>
                 </div>
               )}
 
-              {/* Line left to expansion button */}
-              <div className="w-[10px] h-[1px] bg-gray-300"></div>
-
-              <button
-              aria-label={`Toggle prerequisites for ${prereq.courseID}`}
-              className="px-2 py-1 bg-[#007fff] text-white border-none rounded cursor-pointer text-sm"
-              onClick={() => togglePreReqs(prereq.courseID)}
-              >
-                {expandedPreReqID === prereq.courseID ? ">" : "<"}
+              {/* Expansion button */}
+              <button className="right-3 top-3 z-40 md:top-4 md:right-2">
+                <FlushedButton
+                  onClick={() => togglePreReqs(prereq.courseID)}
+                >
+                  {expandedPreReqID === prereq.courseID ?
+                    <div className="hidden items-center md:flex">
+                      <div className="mr-1">Hide</div>
+                      <ChevronRightIcon className="h-5 w-5" />
+                    </div>
+                    :
+                    <div className="hidden items-center md:flex">
+                      <ChevronLeftIcon className="h-5 w-5" />
+                    </div>
+                  }
+                </FlushedButton>
               </button>
 
-              {/* Line connector left to node */}
-              <div className="w-[10px] h-[1px] bg-[#d1d5db]]"></div>
+              {/* Line right to expansion button */}
+              <div className="w-3 h-0.5 bg-gray-400"></div>
 
-              <Link href={`/course/${prereq.courseID}`} passHref>
-                <div
-                className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer min-w-[80px] mt-[2px] mb-[2px]"
-                >
-                  {prereq.courseID}
-                </div>
-
-              </Link>
+              {/* Course ID button */}
+              <button
+                onClick={() => (window.location.href = `/course/${prereq.courseID}`)}
+                className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
+              >
+                {prereq.courseID}
+              </button>
 
               {/* Line connector right to node */}
               {root.prereqs && root.prereqs.length > 1 && (
-                <div className="w-[20px] h-[1px] bg-[#d1d5db]"></div>
+                <div className="w-3 h-0.5 bg-gray-400"></div>
               )}
 
               {/* Half vertical line for the first prereq in the list */}
               {root.prereqs && root.prereqs.length > 1 && root.prereqs.indexOf(prereq) === 0 && (
-                <div className="w-[1px] h-[20px] bg-[#d1d5db] mt-[20px]"></div>
+                <div className="flex flex-col w-0.5 self-stretch">
+                  <div className="h-1/2 self-stretch"></div>
+                  <div className="w-0.5 h-1/2 bg-gray-400 self-stretch"></div>
+                </div>
               )}
 
               {/* Normal vertical Line connector */}
               {root.prereqs && root.prereqs.length > 1 && root.prereqs.indexOf(prereq) !== 0 && root.prereqs.indexOf(prereq) !== root.prereqs.length - 1 && (
-                <div className="w-[1px] bg-[#d1d5db] self-stretch"></div>
+                <div className="w-0.5 bg-gray-400 self-stretch"></div>
               )}
 
               {/* Half vertical line for the last prereq in the list */}
               {root.prereqs && root.prereqs.length > 1 && root.prereqs.indexOf(prereq) === root.prereqs.length - 1 && (
-                <div className="w-[1px] h-[20px] bg-[#d1d5db] mb-[20px]"></div>
+                <div className="flex flex-col w-0.5 self-stretch">
+                  <div className="w-0.5 h-1/2 bg-gray-400 self-stretch"></div>
+                  <div className="h-1/2 self-stretch"></div>
+                </div>
               )}
 
             </div>
@@ -88,116 +108,101 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
         </div>
       )}
 
-      {/* Main Course in the Center with Corequisites Above and Below */}
-      <div className="flex flex-col items-center">
-        {/* Corequisites Above */}
-        {root.coreqs && root.coreqs.length > 0 && (
-          <div className="text-center">
-            {root.coreqs.slice(0, Math.ceil(root.coreqs.length / 2)).map((coreq) => (
-              <Link href={`/course/${coreq.courseID}`} passHref key={coreq.courseID}>
-                <div
-                className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer min-w-[80px] mt-[2px] mb-[2px]"
-                >
-                  {coreq.courseID}
-                </div>
-              </Link>
-            ))}
-          </div>
+      {/* Main Course */}
+      <div className="flex items-center">
+        {/* Line left to node */}
+        {root.prereqs && root.prereqs.length > 0 && (
+          <div className="w-3 h-0.5 bg-gray-400"></div>
         )}
 
-        {/* Main Course */}
-        <div className="flex items-center">
-          {/* Line connector */}
-          {root.prereqs && root.prereqs.length > 0 && (
-            <div className="w-[20px] h-[1px] bg-[#d1d5db]"></div>
-          )}
-
-          {/* root node */}
-          <div
+        {/* Main node */}
+        <div
           className="font-bold text-center px-2 py-1 text-base bg-[#e5e7eb] text-[#111827] border border-[#9ca3af] rounded shadow-md min-w-[80px] mt-[10px] mb-[10px]"
-          >
-            {root.courseID}
-          </div>
-
-          {/* Line connector */}
-          {root.postreqs && root.postreqs.length > 0 && (
-            <div className="w-[20px] h-[1px] bg-[#d1d5db]"></div>
-          )}
+        >
+          {root.courseID}
         </div>
 
-        {/* Corequisites Below */}
-        {root.coreqs && root.coreqs.length > 0 && (
-          <div className="text-center">
-            {root.coreqs.slice(Math.ceil(root.coreqs.length / 2)).map((coreq) => (
-              <Link href={`/course/${coreq.courseID}`} passHref key={coreq.courseID}>
-                <div
-                className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer min-w-[80px] mt-[2px] mb-[2px]"
-                >
-                  {coreq.courseID}
-                </div>
-              </Link>
-            ))}
-          </div>
+        {/* Line right to node */}
+        {root.postreqs && root.postreqs.length > 0 && (
+          <div className="w-3 h-0.5 bg-gray-400"></div>
         )}
       </div>
 
-      {/* Postrequisites on the Right */}
+      {/* Postreqs on the right */}
       {root.postreqs && root.postreqs.length > 0 && (
-        <div className="flex flex-col items-start">
+        <div className="flex flex-col items-start justify-center">
           {root.postreqs.map((postreq) => (
-            <div key={postreq.courseID} className="flex items-center">
+            <div key={postreq.courseID} className="flex items-center justify-center">
               {/* Half vertical line for the first postreq */}
               {root.postreqs && root.postreqs.length > 1 && root.postreqs.indexOf(postreq) === 0 && (
-                <div className="w-[1px] h-[20px] bg-[#d1d5db] mt-[20px]"></div>
+                <div className="flex flex-col w-0.5 self-stretch">
+                  <div className="h-1/2 self-stretch"></div>
+                  <div className="w-0.5 h-1/2 bg-gray-400 self-stretch"></div>
+                </div>
               )}
 
               {/* Normal vertical Line connector */}
               {root.postreqs && root.postreqs.length > 1 && root.postreqs.indexOf(postreq) !== 0 && root.postreqs.indexOf(postreq) !== root.postreqs.length - 1 && (
-                <div className="w-[1px] bg-[#d1d5db] self-stretch"></div>
+                <div className="w-0.5 bg-gray-400 self-stretch"></div>
               )}
 
               {/* Half vertical line for the last postreq */}
               {root.postreqs && root.postreqs.length > 1 && root.postreqs.indexOf(postreq) === root.postreqs.length - 1 && (
-                <div className="w-[1px] h-[20px] bg-[#d1d5db] mb-[20px]"></div>
+                <div className="flex flex-col w-0.5 self-stretch">
+                  <div className="w-0.5 h-1/2 bg-gray-400 self-stretch"></div>
+                  <div className="h-1/2 self-stretch"></div>
+                </div>
               )}
 
-              {/* Line connector right to postreqs */}
-              <div className="w-[20px] h-[1px] bg-[#d1d5db]"></div>
+              {/* Line left to node */}
+              <div className="w-3 h-0.5 bg-gray-400"></div>
 
-              <Link href={`/course/${postreq.courseID}`} passHref>
-              <div
-              className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer min-w-[80px] mt-[2px] mb-[2px]"
+              {/* Course ID button */}
+              <button
+                onClick={() => (window.location.href = `/course/${postreq.courseID}`)}
+                className="font-normal text-center px-2 py-1 text-base bg-[#f9fafb] text-[#111827] border border-[#d1d5db] rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
               >
                 {postreq.courseID}
-              </div>
-              </Link>
-
-              {/* Line connector right to node */}
-              <div className="w-[10px] h-[1px] bg-[#d1d5db]"></div>
-
-              <button
-              aria-label={`Toggle post-requisites for ${postreq.courseID}`}
-              className= "px-2 py-1 bg-[#007fff] text-white border-none rounded cursor-pointer text-sm"
-              onClick={() => togglePostReqs(postreq.courseID)}
-              >
-                {expandedPostReqID === postreq.courseID ? "<" : ">"}
               </button>
 
+              {/* Line right to node */}
+              <div className="w-3 h-0.5 bg-gray-400"></div>
 
-              {/* Line right to expansion button */}
-              <div className="w-[10px] h-[1px] bg-[#d1d5db]"></div>
+              {/* Expansion button */}
+              <button className="right-3 top-3 z-40 md:top-4 md:right-2">
+                <FlushedButton
+                  onClick={() => togglePostReqs(postreq.courseID)}
+                >
+                  {expandedPostReqID === postreq.courseID ?
+                    <div className="hidden items-center md:flex">
+                      <div className="mr-1">Hide</div>
+                      <ChevronLeftIcon className="h-5 w-5" />
+                    </div>
+                    :
+                    <div className="hidden items-center md:flex">
+                      <ChevronRightIcon className="h-5 w-5" />
+                    </div>
+                  }
+                </FlushedButton>
+              </button>
 
+              {/* Next level of postreqs */}
               {expandedPostReqID === postreq.courseID && (
-                <div>
+                <div className="flex items-center justify-center">
+                  <div className="w-3 h-0.5 bg-gray-400"></div>
                   <PostReqCourses courseID={postreq.courseID} />
                 </div>
               )}
 
             </div>
+
           ))}
+
         </div>
       )}
+
     </div>
+
   );
 };
 

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -1,5 +1,6 @@
-import React from "react";
-import Link from "next/link"; // Import Next.js Link component
+import React, { useState } from "react";
+import Link from "next/link";
+import PostReqCourses from "./PostReqCourses"; // Import PostReqCourses component
 
 interface TreeNode {
   courseID: string;
@@ -12,9 +13,15 @@ interface ReqTreeProps {
 }
 
 const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
+  const [expandedCourseID, setExpandedCourseID] = useState<string | null>(null);
+
+  const togglePostReqs = (courseID: string) => {
+    // Toggle expanded state for the course
+    setExpandedCourseID((prev) => (prev === courseID ? null : courseID));
+  };
+
   return (
     <div style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
-      
       {/* Prerequisites on the Left */}
       {root.prereqs && root.prereqs.length > 0 && (
         <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", marginRight: "20px" }}>
@@ -27,12 +34,13 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                     textAlign: "center",
                     padding: "5px 10px",
                     fontSize: "14px",
-                    backgroundColor: "#f9fafb", 
+                    backgroundColor: "#f9fafb",
                     color: "#111827",
                     border: "1px solid #d1d5db",
                     borderRadius: "4px",
                     boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
                     cursor: "pointer",
+                    minWidth: "80px", // Consistent width
                   }}
                 >
                   {prereq.courseID}
@@ -64,6 +72,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
           borderRadius: "4px",
           boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.1)",
           margin: "0 20px",
+          minWidth: "80px", // Consistent width
         }}
       >
         {root.courseID}
@@ -73,7 +82,15 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
       {root.postreqs && root.postreqs.length > 0 && (
         <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", marginLeft: "20px" }}>
           {root.postreqs.map((postreq) => (
-            <div key={postreq.courseID} style={{ display: "flex", alignItems: "center", marginBottom: "10px" }}>
+            <div
+              key={postreq.courseID}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                marginBottom: "10px",
+                justifyContent: "space-between", // Space between course ID and button
+              }}
+            >
               <div
                 style={{
                   width: "20px",
@@ -89,17 +106,41 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                     textAlign: "center",
                     padding: "5px 10px",
                     fontSize: "14px",
-                    backgroundColor: "#f9fafb", 
+                    backgroundColor: "#f9fafb",
                     color: "#111827",
                     border: "1px solid #d1d5db",
                     borderRadius: "4px",
                     boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
                     cursor: "pointer",
+                    minWidth: "80px", // Consistent width
+                    marginRight: "10px", // Space between course ID and button
                   }}
                 >
                   {postreq.courseID}
                 </div>
               </Link>
+              <button
+                aria-label={`Toggle post-requisites for ${postreq.courseID}`}
+                style={{
+                  marginLeft: "5px",
+                  padding: "5px 10px",
+                  backgroundColor: "#007BFF", // Button color
+                  color: "#FFFFFF",
+                  border: "none",
+                  borderRadius: "4px",
+                  cursor: "pointer",
+                  fontSize: "12px",
+                }}
+                onClick={() => togglePostReqs(postreq.courseID)}
+              >
+                {expandedCourseID === postreq.courseID ? "Hide" : "View More"}
+              </button>
+              {/* Render PostReqCourses dynamically */}
+              {expandedCourseID === postreq.courseID && (
+                <div style={{ marginTop: "10px", marginLeft: "20px" }}>
+                  <PostReqCourses courseID={postreq.courseID} />
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -310,13 +310,15 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               )}
 
               {/* Line connector right to postreqs */}
-              <div
-                style={{
-                  width: "20px",
-                  height: "1px",
-                  backgroundColor: "#d1d5db",
-                }}
-              ></div>
+              {root.postreqs && root.postreqs.length > 1 && (
+                <div
+                  style={{
+                    width: "20px",
+                    height: "1px",
+                    backgroundColor: "#d1d5db",
+                  }}
+                ></div>
+              )}
 
               <Link href={`/course/${postreq.courseID}`} passHref>
                 <div

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -40,6 +40,12 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                 marginBottom: "10px",
               }}
             >
+              {expandedPreReqID === prereq.courseID && (
+                <div style={{ marginRight: "20px" }}>
+                  <PreReqCourses courseID={prereq.courseID} />
+                </div>
+              )}
+
               <button
                 aria-label={`Toggle prerequisites for ${prereq.courseID}`}
                 style={{
@@ -56,6 +62,8 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               >
                 {expandedPreReqID === prereq.courseID ? "Hide" : "View More"}
               </button>
+
+              {/* Line connector */}
 
               <Link href={`/course/${prereq.courseID}`} passHref>
                 <div
@@ -76,12 +84,6 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                   {prereq.courseID}
                 </div>
               </Link>
-
-              {expandedPreReqID === prereq.courseID && (
-                <div style={{ marginTop: "10px", marginLeft: "20px" }}>
-                  <PreReqCourses courseID={prereq.courseID} />
-                </div>
-              )}
             </div>
           ))}
         </div>

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -6,22 +6,29 @@ import {
   ChevronRightIcon,
 } from "@heroicons/react/20/solid";
 import { TreeNode } from "~/app/types";
-import { GetTooltip } from "./GetTooltip";
 
 interface ReqTreeProps {
   root: TreeNode;
 }
 
 const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
-  const [expandedPostReqID, setExpandedPostReqID] = useState<string | null>(null);
-  const [expandedPreReqID, setExpandedPreReqID] = useState<string | null>(null);
+  const [expandedPostReqIDs, setExpandedPostReqIDs] = useState<string[]>([]);
+  const [expandedPreReqIDs, setExpandedPreReqIDs] = useState<string[]>([]);
 
   const togglePostReqs = (courseID: string) => {
-    setExpandedPostReqID((prev) => (prev === courseID ? null : courseID));
+    setExpandedPostReqIDs((prev) =>
+      prev.includes(courseID)
+        ? prev.filter((id) => id !== courseID)
+        : [...prev, courseID]
+    );
   };
 
   const togglePreReqs = (courseID: string) => {
-    setExpandedPreReqID((prev) => (prev === courseID ? null : courseID));
+    setExpandedPreReqIDs((prev) =>
+      prev.includes(courseID)
+        ? prev.filter((id) => id !== courseID)
+        : [...prev, courseID]
+    );
   };
 
   return (
@@ -36,7 +43,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
             <div key={prereq.courseID} className="flex items-center justify-center">
 
               {/* Next level of prereqs */}
-              {expandedPreReqID === prereq.courseID && (
+              {expandedPreReqIDs.includes(prereq.courseID) && (
                 <div className="flex items-center justify-center">
                   <PreReqCourses courseID={prereq.courseID} />
                   <div className="w-3 h-0.5 bg-gray-400"></div>
@@ -48,7 +55,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                 className="text-gray-700 cursor-pointer rounded py-1 px-2 text-sm hover:bg-gray-50"
                 onClick={() => togglePreReqs(prereq.courseID)}
               >
-                {expandedPreReqID === prereq.courseID ? (
+                {expandedPreReqIDs.includes(prereq.courseID) ? (
                   <div className="flex items-center">
                     <div className="mr-1 hidden md:block">Hide</div>
                     <ChevronRightIcon className="h-5 w-5" />
@@ -66,7 +73,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               {/* Course ID button */}
               <button
                 onClick={() => (window.location.href = `/course/${prereq.courseID}`)}
-                className="font-normal text-center px-2 py-1 text-base bg-gray-50 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
+                className="font-normal text-center px-2 py-1 text-base bg-gray-50 hover:bg-gray-200 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
               >
                 {prereq.courseID}
               </button>
@@ -156,7 +163,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               {/* Course ID button */}
               <button
                 onClick={() => (window.location.href = `/course/${postreq.courseID}`)}
-                className="font-normal text-center px-2 py-1 text-base bg-gray-50 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
+                className="font-normal text-center px-2 py-1 text-base bg-gray-50 hover:bg-gray-200 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-[80px] inline mt-[2px] mb-[2px]"
               >
                 {postreq.courseID}
               </button>
@@ -169,7 +176,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                 className="text-gray-700 cursor-pointer rounded py-1 px-2 text-sm hover:bg-gray-50"
                 onClick={() => togglePostReqs(postreq.courseID)}
               >
-                {expandedPostReqID === postreq.courseID ? (
+                {expandedPostReqIDs.includes(postreq.courseID) ? (
                   <div className="flex items-center">
                     <div className="mr-1 hidden md:block">Hide</div>
                     <ChevronLeftIcon className="h-5 w-5" />
@@ -182,7 +189,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               </div>
 
               {/* Next level of postreqs */}
-              {expandedPostReqID === postreq.courseID && (
+              {expandedPostReqIDs.includes(postreq.courseID) && (
                 <div className="flex items-center justify-center">
                   <div className="w-3 h-0.5 bg-gray-400"></div>
                   <PostReqCourses courseID={postreq.courseID} />


### PR DESCRIPTION
# Description

This pull request adds the requisite tree feature, which shows a tree of pre-requisites and post-requisites of courses in the course detail page. The feature enhances the user experience by providing a clear and organized visual representation of course dependencies. 

<img width="1088" alt="tree" src="https://github.com/user-attachments/assets/67384605-c379-4177-a3fc-123f334d2a22" />

Closes #53

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
This feature was tested mainly through manual testing since most parts of the implementation were about the visualization and rendering of the tree. Error handling techniques were used to ensure error-free code, as well as manual validation. Backend testing also took place, as we tested the outputs of new functions we implemented. 

**Test Configuration**:
- Node.js version: 22.7.0
- Desktop/Mobile: Desktop 
- OS: Mac Sonoma
- Browser: Chrome

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
