### PR TITLE
add alternating row colors for better readability to geneds table (#227)

### DIFF
--- a/apps/frontend/src/components/GenedsDataTable.tsx
+++ b/apps/frontend/src/components/GenedsDataTable.tsx
@@ -155,18 +155,21 @@ export const GenedsDataTable = ({ data }: { data: Gened[] }) => {
         ))}
       </thead>
       <tbody>
-        {table.getRowModel().rows.map((row) => (
-          <tr key={row.id} className="hover:bg-white">
-            {row.getVisibleCells().map((cell) => (
-              <td
-                className="whitespace-nowrap px-2 text-sm text-gray-600"
-                key={cell.id}
-              >
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              </td>
-            ))}
-          </tr>
-        ))}
+        {table.getRowModel().rows.map((row,idx) => {
+          const bgColor = idx % 2 == 0 ? "bg-white" : "bg-gray-50"; 
+          return (
+            <tr key={row.id} className={`${bgColor} hover:bg-gray-100 dark:hover:bg-gray-200`}>
+              {row.getVisibleCells().map((cell) => (
+                <td
+                  className="whitespace-nowrap px-2 text-sm text-gray-600"
+                  key={cell.id}
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   );


### PR DESCRIPTION
Closes #227
adds alternating background colors to the geneds table rows to improve readability and visual scanning
lowkey not super happy with the colors in light mode, i wanted the hover to be lighter than the columns
anish am i ur fav slabs parent yet