### PR TITLE
fix: dark mode styles for schedule calendar and section selector, and…

### DIFF
--- a/apps/frontend/src/components/ScheduleCalendar.tsx
+++ b/apps/frontend/src/components/ScheduleCalendar.tsx
@@ -286,7 +286,8 @@ const ScheduleCalendar = ({ courseIDs }: Props) => {
         },
         eventPropGetter: (event: Event) => ({
           style: {
-            color: "#030712",
+            color: "#374151", //text-gray-700
+            border: "1px solid #1f2937", //border-gray-800
             backgroundColor: event.color,
           },
         }),
@@ -294,7 +295,7 @@ const ScheduleCalendar = ({ courseIDs }: Props) => {
     }, []);
 
   return (
-    <div className="m-6 p-4 bg-white rounded-md">
+    <div className="m-6 p-4 bg-white text-gray-700 rounded-md"> 
       <Calendar
         defaultDate={defaultDate}
         defaultView="week"

--- a/apps/frontend/src/components/SectionSelector.tsx
+++ b/apps/frontend/src/components/SectionSelector.tsx
@@ -175,13 +175,13 @@ const SectionSelector = ({ courseIDs }: { courseIDs: string[] }) => {
             return (
               <div
                 key={courseID}
-                className="relative mb-4 p-3 rounded-md border border-black"
+                className="relative mb-4 p-3 rounded-md border border-gray-800 dark:border-gray-200"
                 style={{
                   backgroundColor:
                     selectedCourseSessions[courseID]?.Color || "",
                 }}
               >
-                <div className="flex justify-between text-lg">
+                <div className="flex justify-between text-lg text-gray-700 dark:text-gray-300">
                   {courseID} (Select {sessionType})
                   <span
                     className="cursor-pointer"
@@ -199,7 +199,7 @@ const SectionSelector = ({ courseIDs }: { courseIDs: string[] }) => {
                 </div>
                 <div>
                   <RadioGroup
-                    className="grid grid-flow-col divide-x divide-gray-400 justify-stretch rounded-md border border-black overflow-x-auto"
+                    className="grid grid-flow-col divide-x divide-gray-400 dark:divide-gray-400 justify-stretch rounded-md border border-gray-800 dark:border-gray-200 overflow-x-auto"
                     value={selectedCourseSession}
                     onChange={(payload) => {
                       if (sessionType === "Section") {
@@ -242,7 +242,7 @@ const SectionSelector = ({ courseIDs }: { courseIDs: string[] }) => {
                         className={({ active }) => {
                           return classNames(
                             "flex relative justify-center cursor-pointer select-none focus:outline-none",
-                            "hover:bg-gray-200 p-1",
+                            "hover:bg-gray-200 dark:hover:bg-gray-700 p-1",
                             i === 0 ? "rounded-l-md pl-1" : "",
                             i === sessions.length - 1
                               ? "rounded-r-md pr-1"
@@ -280,7 +280,7 @@ const SectionSelector = ({ courseIDs }: { courseIDs: string[] }) => {
                           <span className="block truncate">
                             <span
                               className={classNames(
-                                "text-gray-700",
+                                "text-gray-700 dark:text-gray-300",
                                 checked ? "font-semibold" : "font-normal"
                               )}
                             >


### PR DESCRIPTION
… align colors with site theme
applies consistent border and text colors and matches colors with site theme in both light and dark mode (gets rid of random black stuff)
Closes #226 